### PR TITLE
Introduce retry flag on item's finish. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     } else {
         compile('com.github.reportportal:commons-dao:4.0.0')
         compile('com.github.reportportal:commons-rules:4.0.0')
-        compile 'com.github.reportportal:commons-model:4.0.0'
+        compile 'com.github.reportportal:commons-model:36edbf5'
         compile('com.github.reportportal:commons:3.1.0')
     }
 

--- a/src/main/java/com/epam/ta/reportportal/core/item/FinishTestItemHandlerImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/item/FinishTestItemHandlerImpl.java
@@ -129,7 +129,7 @@ class FinishTestItemHandlerImpl implements FinishTestItemHandler {
 		if (finishExecutionRQ.getRetry()) {
 			testItem.setRetryProcessed(Boolean.FALSE);
 			if (BooleanUtils.isNotTrue(launch.getHasRetries())) {
-				launchRepository.updateHasRetries(testItem.getLaunchRef(), true);
+				launchRepository.updateHasRetries(launch.getId(), true);
 			}
 		}
 

--- a/src/main/java/com/epam/ta/reportportal/core/launch/impl/RetriesLaunchHandler.java
+++ b/src/main/java/com/epam/ta/reportportal/core/launch/impl/RetriesLaunchHandler.java
@@ -87,10 +87,9 @@ public class RetriesLaunchHandler implements IRetriesLaunchHandler {
 	private void handleRetry(RetryObject retry, StatisticsFacade statisticsFacade) {
 		List<TestItem> retries = retry.getRetries();
 		expect((retries.size() >= MINIMUM_RETRIES_COUNT), isEqual(true)).verify(
-				ErrorType.RETRIES_HANDLER_ERROR, "Minimum retries count is " + MINIMUM_RETRIES_COUNT
-		);
-		retries.forEach(it -> expect(it.hasChilds(), equalTo(false)).verify(
-				ErrorType.RETRIES_HANDLER_ERROR, "Retries cannot have items with children"
+				ErrorType.RETRIES_HANDLER_ERROR, "Minimum retries count is " + MINIMUM_RETRIES_COUNT);
+		retries.forEach(it -> expect(it.hasChilds(), equalTo(false)).verify(ErrorType.RETRIES_HANDLER_ERROR,
+				"Retries cannot have items with children"
 		));
 		TestItem lastRetry = moveRetries(retries, statisticsFacade);
 		testItemRepository.delete(retries);
@@ -124,9 +123,11 @@ public class RetriesLaunchHandler implements IRetriesLaunchHandler {
 	 * @return Last retry
 	 */
 	private TestItem moveRetries(List<TestItem> retries, StatisticsFacade statisticsFacade) {
-		retries.forEach(it -> it.setRetryProcessed(Boolean.TRUE));
+		retries.forEach(it -> {
+			resetRetryStatistics(it, statisticsFacade);
+			it.setRetryProcessed(Boolean.TRUE);
+		});
 		TestItem retryRoot = retries.get(0);
-		retryRoot = resetRetryStatistics(retryRoot, statisticsFacade);
 		retries.set(0, retryRoot);
 
 		TestItem lastRetry = retries.get(retries.size() - 1);


### PR DESCRIPTION
According to TestNG specialty of items current invocation counting in multithreading launch
should be added another check on item's finish. Also it is not really need to hide the statistics while retries are running. It is recalculated on the launch's finish.