### PR TITLE
AutoAnalyzed flag fix

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/item/UpdateTestItemHandlerImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/item/UpdateTestItemHandlerImpl.java
@@ -125,8 +125,6 @@ public class UpdateTestItemHandlerImpl implements UpdateTestItemHandler {
 				verifyTestItem(testItem, issueDefinition.getId());
 				TestItem before = SerializationUtils.clone(testItem);
 
-				//if item is updated then it is no longer auto analyzed
-				issueDefinition.getIssue().setAutoAnalyzed(false);
 				eventData.put(issueDefinition, testItem);
 
 				final Launch launch = launchRepository.findOne(testItem.getLaunchRef());


### PR DESCRIPTION
AutoAnalyzed flag will depend on data, that was received from Client, instead of always being "false". If no data received from Client, flag will be "false" by default.

https://github.com/reportportal/reportportal/issues/427 