### PR TITLE
Fix start script in Dockerfiles with openjdk:11-jre-slim base image

### DIFF
--- a/docker/Dockerfile-dev-release
+++ b/docker/Dockerfile-dev-release
@@ -15,7 +15,8 @@ ENV APP_DOWNLOAD_URL https://dl.bintray.com/epam/reportportal/com/epam/reportpor
 RUN apt-get update && \
     apt-get install fonts-noto-core -y
 
-RUN echo $'#!/bin/sh \n exec java ${JAVA_OPTS} -jar ${APP_FILE}' > /start.sh && chmod +x /start.sh
+RUN echo '#!/bin/sh \n exec java ${JAVA_OPTS} -jar ${APP_FILE}' > /start.sh && \
+    chmod +x /start.sh
 
 # Set default JAVA_OPTS and JAVA_APP
 ENV JAVA_OPTS="-Xmx1g -Djava.security.egd=file:/dev/./urandom"

--- a/docker/Dockerfile-develop
+++ b/docker/Dockerfile-develop
@@ -50,7 +50,8 @@ LABEL description="ReportPortal API Service: Development Version"
 RUN apt-get update && \
     apt-get install fonts-noto-core -y
 
-RUN echo $'#!/bin/sh \n exec java ${JAVA_OPTS} -jar ${APP_FILE}' > /start.sh && chmod +x /start.sh
+RUN echo '#!/bin/sh \n exec java ${JAVA_OPTS} -jar ${APP_FILE}' > /start.sh && \
+    chmod +x /start.sh
 
 # Set default JAVA_OPTS and JAVA_APP
 ENV JAVA_OPTS="-DLOG_FILE=app.log -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"

--- a/docker/Dockerfile-release
+++ b/docker/Dockerfile-release
@@ -10,7 +10,7 @@ ENV APP_DOWNLOAD_URL=https://dl.bintray.com/epam/reportportal/com/epam/reportpor
 RUN apt-get update && \
     apt-get install wget unzip openssl -y && \
     # Create start.sh script
-    echo $'#!/bin/sh \n exec java ${JAVA_OPTS} -jar ${APP_FILE}' > /start.sh && \
+    echo '#!/bin/sh \n exec java ${JAVA_OPTS} -jar ${APP_FILE}' > /start.sh && \
     chmod +x /start.sh && \
     # Download application
     wget -O /${APP_FILE} ${APP_DOWNLOAD_URL} && \


### PR DESCRIPTION
@HardNorth I've got the mistake with startup script definition in Dockerfiles with `openjdk:11-jre-slim`
It's because I've used Dockerfile in the root folder for testing and it contains `alpine` image as basic.
So, that's why we have different `echo` command outputs
Sorry for leading you to wrong way