### PR TITLE
#1196 Add minio bucket configuration properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         compile 'com.epam.reportportal:commons-fonts'
         compile 'com.epam.reportportal:plugin-api'
     } else {
-        compile 'com.github.reportportal:commons-dao:0f7079e'
+        compile 'com.github.reportportal:commons-dao:4f58928'
         compile 'com.github.reportportal:commons-rules:331c402'
         compile 'com.github.reportportal:commons-model:b0bc3f7'
         compile 'com.github.reportportal:commons:7480d61'

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         compile 'com.epam.reportportal:commons-fonts'
         compile 'com.epam.reportportal:plugin-api'
     } else {
-        compile 'com.github.reportportal:commons-dao:4f58928'
+        compile 'com.github.reportportal:commons-dao:4dc6327'
         compile 'com.github.reportportal:commons-rules:331c402'
         compile 'com.github.reportportal:commons-model:b0bc3f7'
         compile 'com.github.reportportal:commons:7480d61'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,6 +51,8 @@ datastore.minio.endpoint=\${rp.binarystore.minio.endpoint:https://play.min.io}
 datastore.minio.accessKey=\${rp.binarystore.minio.accessKey:Q3AM3UQ867SPQQA43P2F}
 datastore.minio.secretKey=\${rp.binarystore.minio.secretKey:zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG}
 datastore.minio.region=\${rp.binarystore.minio.region:#{null}}
+datastore.minio.bucketPrefix=\${rp.binarystore.minio.bucketPrefix:prj-}
+datastore.minio.defaultBucketName=\${rp.binarystore.minio.defaultBucketName:rp-bucket}
 # could be one of [seaweed, filesystem, minio]
 datastore.type=\${rp.binarystore.type:filesystem}
 datastore.thumbnail.attachment.width=\${rp.binarystore.thumbnail.attachment.width:80}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,6 +113,8 @@ rp:
       endpoint: http://play.min.io
       accessKey: Q3AM3UQ867SPQQA43P2F
       secretKey: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
+      bucketPrefix: prj-
+      defaultBucketName: rp-bucket
     # could be one of [seaweed, filesystem, minio]
     type: filesystem
     thumbnail:


### PR DESCRIPTION
Add default configurations for `datastore.minio.bucketPrefix` and `datastore.minio.defaultBucketName`.

Allows to fix https://github.com/reportportal/service-api/issues/1196 and https://github.com/reportportal/kubernetes/issues/115