### PR TITLE
Add group write permission to default /plugins dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM openjdk:11-jre-slim
 LABEL version=5.1.0 description="EPAM Report portal. Main API Service" maintainer="Andrei Varabyeu <andrei_varabyeu@epam.com>"
 RUN apt-get update -qq && apt-get install -qq -y wget fontconfig
 ENV JAVA_OPTS="-Xmx1g -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=70 -Djava.security.egd=file:/dev/./urandom" ARTIFACT=service-api-5.1.0-exec.jar APP_DOWNLOAD_URL=https://dl.bintray.com/epam/reportportal/com/epam/reportportal/service-api/5.1.0/service-api-5.1.0-exec.jar
-RUN echo $'exec java $JAVA_OPTS -jar $ARTIFACT' > /start.sh && chmod +x /start.sh
+RUN echo $'exec java $JAVA_OPTS -jar $ARTIFACT' > /start.sh && \
+    chmod +x /start.sh && \
+    mkdir /plugins && \
+    chmod g+w /plugins
 VOLUME ["/tmp"]
 RUN wget $APP_DOWNLOAD_URL
 EXPOSE 8080

--- a/docker/Dockerfile-dev-release
+++ b/docker/Dockerfile-dev-release
@@ -16,7 +16,9 @@ RUN apt-get update && \
     apt-get install fonts-noto-core -y
 
 RUN echo '#!/bin/sh \n exec java ${JAVA_OPTS} -jar ${APP_FILE}' > /start.sh && \
-    chmod +x /start.sh
+    chmod +x /start.sh && \
+    mkdir /plugins && \
+    chmod g+w /plugins
 
 # Set default JAVA_OPTS and JAVA_APP
 ENV JAVA_OPTS="-Xmx1g -Djava.security.egd=file:/dev/./urandom"

--- a/docker/Dockerfile-release
+++ b/docker/Dockerfile-release
@@ -15,7 +15,10 @@ RUN apt-get update && \
     # Download application
     wget -O /${APP_FILE} ${APP_DOWNLOAD_URL} && \
     # Remove APT cache
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    # Grant group write permission for plugins dir
+    mkdir /plugins && \
+    chmod g+w /plugins
 
 # Set default JAVA_OPTS
 ENV JAVA_OPTS="-Xmx1g -Djava.security.egd=file:/dev/./urandom"


### PR DESCRIPTION
Even though the data will be stored via minio, still the app need
permission to add the contents under the dir when run in rootless
container with group access env like OpenShift.
Signed-off-by: Wayne Sun <gsun@redhat.com>