### PR TITLE
Expose prometheus endpoints without authentication

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/configs/SecurityConfiguration.java
+++ b/src/main/java/com/epam/ta/reportportal/core/configs/SecurityConfiguration.java
@@ -189,6 +189,8 @@ class SecurityConfiguration {
 							"/**/user/password/restore**",
 							"/documentation.html",
 							"/health",
+							"/metrics",
+							"/prometheus",
 							"/info"
 					)
 					.permitAll()


### PR DESCRIPTION
PR#1053 have switched to Spring prometheus metrics, and enabled
the endpoints /metrics and /prometheus.

For prometheus scraping it should not require authentication, so
expose the endpoints like /health.

Signed-off-by: Wayne Sun <gsun@redhat.com>