### PR TITLE
Swagger: add base path

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/configs/Swagger2Configuration.java
+++ b/src/main/java/com/epam/ta/reportportal/core/configs/Swagger2Configuration.java
@@ -92,11 +92,9 @@ public class Swagger2Configuration {
 	@Autowired
 	private ServletContext servletContext;
 
-	@Autowired
 	@Value("${spring.application.name}")
-	private String eurekaName;
+	private String applicationName;
 
-	@Autowired
 	@Value("${info.build.version}")
 	private String buildVersion;
 
@@ -132,7 +130,12 @@ public class Swagger2Configuration {
 
 	@Bean
 	public PathProvider rpPathProvider() {
-		return new RelativePathProvider(servletContext);
+		return new RelativePathProvider(servletContext) {
+			@Override
+			public String getApplicationBasePath() {
+				return "/" + applicationName + super.getApplicationBasePath();
+			}
+		};
 	}
 
 	@Bean


### PR DESCRIPTION
Refer `service-authorization` PR # [91](https://github.com/reportportal/service-authorization/pull/91)

This change is somehow missed in `service-api`. Because of which, basePath is populated as blank when running in kubernetes.