### PR TITLE
Environment variable to specify a RabbitMQ host

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/configs/rabbit/AnalyzerRabbitMqConfiguration.java
+++ b/src/main/java/com/epam/ta/reportportal/core/configs/rabbit/AnalyzerRabbitMqConfiguration.java
@@ -64,7 +64,7 @@ public class AnalyzerRabbitMqConfiguration {
 	@Bean(name = "analyzerConnectionFactory")
 	public ConnectionFactory analyzerConnectionFactory(@Value("${rp.amqp.addresses}") URI addresses) {
 		CachingConnectionFactory factory = new CachingConnectionFactory(addresses);
-		factory.setVirtualHost(@Value("${rp.amqp.virtualhost:” + ANALYZER_KEY + “}”);
+		factory.setVirtualHost(@Value("${rp.amqp.virtualhost:" + ANALYZER_KEY + "}");
 		return factory;
 	}
 

--- a/src/main/java/com/epam/ta/reportportal/core/configs/rabbit/AnalyzerRabbitMqConfiguration.java
+++ b/src/main/java/com/epam/ta/reportportal/core/configs/rabbit/AnalyzerRabbitMqConfiguration.java
@@ -64,7 +64,7 @@ public class AnalyzerRabbitMqConfiguration {
 	@Bean(name = "analyzerConnectionFactory")
 	public ConnectionFactory analyzerConnectionFactory(@Value("${rp.amqp.addresses}") URI addresses) {
 		CachingConnectionFactory factory = new CachingConnectionFactory(addresses);
-		factory.setVirtualHost(ANALYZER_KEY);
+		factory.setVirtualHost(@Value("${rp.amqp.virtualhost:” + ANALYZER_KEY + “}”);
 		return factory;
 	}
 


### PR DESCRIPTION
Inject a variable from properties or command line args. 
This change allows usage of single RabbitMQ cluster for multiple RP instances.