### PR TITLE
EPMRPP-86945 ||Check application name into Swagger base-path

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/configs/Swagger2Configuration.java
+++ b/src/main/java/com/epam/ta/reportportal/core/configs/Swagger2Configuration.java
@@ -98,9 +98,6 @@ public class Swagger2Configuration {
   @Value("${info.build.version}")
   private String buildVersion;
 
-  @Value("${rp.swagger.use-path-prefix}")
-  private boolean usePathPrefix;
-
 	@Bean
 	public Docket docket() {
 		/* For more information see default params at {@link ApiInfo} */
@@ -137,7 +134,7 @@ public class Swagger2Configuration {
     return new RelativePathProvider(servletContext) {
       @Override
       public String getApplicationBasePath() {
-        if (!usePathPrefix) {
+        if (super.getApplicationBasePath().contains(applicationName)) {
           return super.getApplicationBasePath();
         }
         return "/" + applicationName + super.getApplicationBasePath();

--- a/src/main/java/com/epam/ta/reportportal/core/configs/Swagger2Configuration.java
+++ b/src/main/java/com/epam/ta/reportportal/core/configs/Swagger2Configuration.java
@@ -98,6 +98,9 @@ public class Swagger2Configuration {
   @Value("${info.build.version}")
   private String buildVersion;
 
+  @Value("${rp.swagger.use-path-prefix}")
+  private boolean usePathPrefix;
+
 	@Bean
 	public Docket docket() {
 		/* For more information see default params at {@link ApiInfo} */
@@ -134,6 +137,9 @@ public class Swagger2Configuration {
     return new RelativePathProvider(servletContext) {
       @Override
       public String getApplicationBasePath() {
+        if (!usePathPrefix) {
+          return super.getApplicationBasePath();
+        }
         return "/" + applicationName + super.getApplicationBasePath();
       }
     };

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -175,6 +175,8 @@ rp:
       avatar:
         width: 40
         height: 50
+  swagger:
+    use-path-prefix: true
 
 datastore:
   path: /data/storage

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -175,8 +175,6 @@ rp:
       avatar:
         width: 40
         height: 50
-  swagger:
-    use-path-prefix: true
 
 datastore:
   path: /data/storage


### PR DESCRIPTION
By using it, we can prevent the duplication of names in the Swagger host path like this: `/api/api`