### PR TITLE
EPMRPP-86812 || extended actuator with "jobs" module info

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/health/JobsHealthIndicator.java
+++ b/src/main/java/com/epam/ta/reportportal/health/JobsHealthIndicator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.ta.reportportal.health;
+
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+
+/**
+ * Health Indicator for jobs service.
+ *
+ * @author Siarhei Hrabko
+ */
+@Component
+public class JobsHealthIndicator extends AbstractHealthIndicator {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(JobsHealthIndicator.class);
+  private static final String ERROR_MESSAGE = "Jobs service health check failed";
+  RestTemplate restTemplate;
+
+  @Value("${rp.jobs.baseUrl}")
+  private String jobsBaseUrl;
+
+  public JobsHealthIndicator() {
+    super(ERROR_MESSAGE);
+    this.restTemplate = new RestTemplate();
+  }
+
+  @Override
+  protected void doHealthCheck(Builder builder) {
+    try {
+      var jobsHealthRs = restTemplate.getForObject(jobsBaseUrl + "/health", Map.class);
+
+      var jobsStatus = new Status((String) jobsHealthRs.get("status"));
+      builder.status(jobsStatus);
+
+      Optional.ofNullable(jobsHealthRs.get("components"))
+          .map(Map.class::cast)
+          .ifPresent(builder::withDetails);
+
+      builder.build();
+
+    } catch (Exception e) {
+      LOGGER.error("{} : {}", ERROR_MESSAGE, e.getMessage());
+      builder.unknown()
+          .withException(e)
+          .build();
+    }
+  }
+
+  @Override
+  public Health getHealth(boolean includeDetails) {
+    return super.getHealth(includeDetails);
+  }
+
+}

--- a/src/main/java/com/epam/ta/reportportal/info/JobsInfoContributor.java
+++ b/src/main/java/com/epam/ta/reportportal/info/JobsInfoContributor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.ta.reportportal.info;
+
+import com.epam.ta.reportportal.exception.ReportPortalException;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.info.Info.Builder;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+
+/**
+ * Picks actuator info from <i>jobs</i> service and shows it as part of <i>service-api</i>.
+ *
+ * @author Siarhei Hrabko
+ */
+@Component
+public class JobsInfoContributor implements InfoContributor {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${rp.jobs.baseUrl}")
+  private String jobsBaseUrl;
+
+  public JobsInfoContributor() {
+    this.restTemplate = new RestTemplate();
+  }
+
+  @Override
+  public void contribute(Builder builder) {
+    try {
+      var jobsInfoRs = restTemplate.getForObject(jobsBaseUrl + "/info", Map.class);
+      builder
+          .withDetail("jobsInfo", jobsInfoRs)
+          .build();
+    } catch (Exception e) {
+      throw new ReportPortalException(e.getMessage());
+    }
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -137,6 +137,10 @@ rp:
   jwt:
     signing-key:
 
+
+  jobs:
+    baseUrl: http://jobs:8686
+
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.postgresql.Driver


### PR DESCRIPTION
In order to show detailed health information, the property `management.endpoint.health.show-details=always`
 should be set in `application.properties` for both `service-api` and `jobs-service` projects