### PR TITLE
Use default HttpMessageConverter

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/configs/MvcConfig.java
+++ b/src/main/java/com/epam/ta/reportportal/core/configs/MvcConfig.java
@@ -110,13 +110,6 @@ public class MvcConfig implements WebMvcConfigurer {
 	}
 
 	@Override
-	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
-		converters.clear();
-		converters.add(jsonConverter());
-		converters.add(stringConverter());
-	}
-
-	@Override
 	public void configureHandlerExceptionResolvers(List<HandlerExceptionResolver> exceptionResolvers) {
 		/* to propagate exceptions from downstream services */
 		ClientResponseForwardingExceptionHandler forwardingExceptionHandler = new ClientResponseForwardingExceptionHandler();


### PR DESCRIPTION
Remove configureMessageConverters to use default HttpMessageConverter that properly handles

- application/json
- text/plain
- application/openmetrics-text

https://github.com/reportportal/reportportal/issues/1999