### PR TITLE
EPMRPP-87382 fixed user attachments double removal

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/remover/user/UserPhotoRemover.java
+++ b/src/main/java/com/epam/ta/reportportal/core/remover/user/UserPhotoRemover.java
@@ -49,11 +49,8 @@ public class UserPhotoRemover implements ContentRemover<User> {
     ofNullable(user.getAttachment()).ifPresent(fileId -> {
       List<Long> attachmentsIds = new ArrayList<>(2);
       attachmentsIds.add(prepareAttachmentAndGetId(fileId));
-      user.setAttachment(null);
-      Optional.ofNullable(user.getAttachmentThumbnail()).ifPresent(thumbnailId -> {
-        attachmentsIds.add(prepareAttachmentAndGetId(thumbnailId));
-        user.setAttachmentThumbnail(null);
-      });
+      Optional.ofNullable(user.getAttachmentThumbnail())
+          .ifPresent(thumbnailId -> attachmentsIds.add(prepareAttachmentAndGetId(thumbnailId)));
       ofNullable(user.getMetadata()).ifPresent(
           metadata -> metadata.getMetadata().remove(ATTACHMENT_CONTENT_TYPE));
       attachmentRepository.moveForDeletion(attachmentsIds);


### PR DESCRIPTION
Impossible to process attachments in data storage because of already removed references in user storage
No need to remove these properties twice

Another solution, deep copy of user object could be passed as the parameter here https://github.com/reportportal/service-api/blob/develop/src/main/java/com/epam/ta/reportportal/core/user/impl/DeleteUserHandlerImpl.java#L120
