### PR TITLE
Adjust email recipient in sendConnectionTestEmail

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
@@ -17,7 +17,7 @@
 package com.epam.ta.reportportal.core.integration.util;
 
 import static com.epam.reportportal.rules.commons.validation.BusinessRule.fail;
-import static com.epam.reportportal.rules.exception.ErrorType.FORBIDDEN_OPERATION;
+import static com.epam.reportportal.rules.exception.ErrorType.EMAIL_CONFIGURATION_IS_INCORRECT;
 import static java.util.Optional.ofNullable;
 
 import com.epam.reportportal.rules.commons.validation.BusinessRule;
@@ -31,7 +31,6 @@ import com.epam.ta.reportportal.util.email.EmailService;
 import com.epam.ta.reportportal.util.email.MailServiceFactory;
 import com.google.common.collect.Maps;
 import com.mchange.lang.IntegerUtils;
-import java.io.UnsupportedEncodingException;
 import java.util.Map;
 import java.util.Optional;
 import javax.mail.MessagingException;
@@ -178,7 +177,7 @@ public class EmailServerIntegrationService extends BasicIntegrationServiceImpl {
         LOGGER.error("Cannot send email to user", ex);
         fail()
             .withError(
-                FORBIDDEN_OPERATION,
+                EMAIL_CONFIGURATION_IS_INCORRECT,
                 "Email configuration is incorrect. Please, check your configuration. "
                     + ex.getMessage());
       }

--- a/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
@@ -31,7 +31,6 @@ import com.epam.ta.reportportal.util.email.EmailService;
 import com.epam.ta.reportportal.util.email.MailServiceFactory;
 import com.google.common.collect.Maps;
 import com.mchange.lang.IntegerUtils;
-
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
 import java.util.Optional;
@@ -182,7 +181,7 @@ public class EmailServerIntegrationService extends BasicIntegrationServiceImpl {
                 FORBIDDEN_OPERATION,
                 "Email configuration is incorrect. Please, check your configuration. "
                     + ex.getMessage());
-        }
+      }
     } else {
       return false;
     }

--- a/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
@@ -61,6 +61,14 @@ public class EmailServerIntegrationService extends BasicIntegrationServiceImpl {
 
   private final MailServiceFactory emailServiceFactory;
 
+  /**
+ * Constructs an EmailServerIntegrationService with the specified dependencies.
+ *
+ * @param integrationRepository the repository for integration entities
+ * @param pluginBox the plugin box for managing plugins
+ * @param basicTextEncryptor the text encryptor for encrypting sensitive data
+ * @param emailServiceFactory the factory for creating email services
+ */
   public EmailServerIntegrationService(
       IntegrationRepository integrationRepository,
       PluginBox pluginBox,

--- a/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
@@ -174,7 +174,7 @@ public class EmailServerIntegrationService extends BasicIntegrationServiceImpl {
                 .orElse("false"))) {
           emailService.get().sendConnectionTestEmail(isIntegrationCreated);
         }
-      } catch (MessagingException | UnsupportedEncodingException ex) {
+      } catch (MessagingException ex) {
         LOGGER.error("Cannot send email to user", ex);
         fail()
             .withError(

--- a/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/util/EmailServerIntegrationService.java
@@ -17,30 +17,23 @@
 package com.epam.ta.reportportal.core.integration.util;
 
 import static com.epam.reportportal.rules.commons.validation.BusinessRule.fail;
-import static com.epam.reportportal.rules.commons.validation.Suppliers.formattedSupplier;
-import static com.epam.reportportal.rules.exception.ErrorType.EMAIL_CONFIGURATION_IS_INCORRECT;
 import static com.epam.reportportal.rules.exception.ErrorType.FORBIDDEN_OPERATION;
 import static java.util.Optional.ofNullable;
 
 import com.epam.reportportal.rules.commons.validation.BusinessRule;
+import com.epam.reportportal.rules.exception.ErrorType;
 import com.epam.ta.reportportal.core.admin.ServerAdminHandlerImpl;
 import com.epam.ta.reportportal.core.plugin.PluginBox;
 import com.epam.ta.reportportal.dao.IntegrationRepository;
 import com.epam.ta.reportportal.entity.EmailSettingsEnum;
 import com.epam.ta.reportportal.entity.integration.Integration;
-import com.epam.reportportal.rules.exception.ReportPortalException;
 import com.epam.ta.reportportal.util.email.EmailService;
 import com.epam.ta.reportportal.util.email.MailServiceFactory;
-import com.epam.reportportal.rules.exception.ErrorType;
 import com.google.common.collect.Maps;
 import com.mchange.lang.IntegerUtils;
-
 import java.util.Map;
 import java.util.Optional;
 import javax.mail.MessagingException;
-import javax.mail.Transport;
-import javax.mail.internet.AddressException;
-
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.validator.routines.UrlValidator;
@@ -50,6 +43,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 /**
+ * Service for integration with email server.
+ *
  * @author <a href="mailto:ivan_budayeu@epam.com">Ivan Budayeu</a>
  */
 @Service
@@ -62,13 +57,13 @@ public class EmailServerIntegrationService extends BasicIntegrationServiceImpl {
   private final MailServiceFactory emailServiceFactory;
 
   /**
- * Constructs an EmailServerIntegrationService with the specified dependencies.
- *
- * @param integrationRepository the repository for integration entities
- * @param pluginBox the plugin box for managing plugins
- * @param basicTextEncryptor the text encryptor for encrypting sensitive data
- * @param emailServiceFactory the factory for creating email services
- */
+   * Constructs an EmailServerIntegrationService with the specified dependencies.
+   *
+   * @param integrationRepository the repository for integration entities
+   * @param pluginBox the plugin box for managing plugins
+   * @param basicTextEncryptor the text encryptor for encrypting sensitive data
+   * @param emailServiceFactory the factory for creating email services
+   */
   public EmailServerIntegrationService(
       IntegrationRepository integrationRepository,
       PluginBox pluginBox,

--- a/src/main/java/com/epam/ta/reportportal/util/email/EmailService.java
+++ b/src/main/java/com/epam/ta/reportportal/util/email/EmailService.java
@@ -351,10 +351,12 @@ public class EmailService extends JavaMailSenderImpl {
    */
   public void setFrom(String from) {
     try {
-      switch (from) {
-        case String s when s.contains("<") -> this.from = new InternetAddress(from);
-        case String s when UserUtils.isEmailValid(s) -> this.from = new InternetAddress(from, null);
-        default -> this.from = null;
+      if (from.contains("<")) {
+        this.from = new InternetAddress(from);
+      } else if (UserUtils.isEmailValid(from)) {
+        this.from = new InternetAddress(from, null);
+      } else {
+        this.from = null;
       }
     } catch (AddressException | UnsupportedEncodingException e) {
       this.from = null;

--- a/src/main/java/com/epam/ta/reportportal/util/email/EmailService.java
+++ b/src/main/java/com/epam/ta/reportportal/util/email/EmailService.java
@@ -348,7 +348,13 @@ public class EmailService extends JavaMailSenderImpl {
       String subject =
           isCreated ? "Email server integration creation" : "Email server integration updated";
       message.setSubject(subject);
-      message.setTo(sendTo);
+      if (UserUtils.isEmailValid(sendTo) && isAddressValid(sendTo)) {
+        message.setTo(sendTo);
+      } else if (UserUtils.isEmailValid(this.from) && isAddressValid(this.from)) {
+        message.setTo(this.from);
+      } else {
+        message.setTo("test@example.com");
+      }
       setFrom(message);
 
       Map<String, Object> data = Collections.emptyMap();

--- a/src/main/java/com/epam/ta/reportportal/util/email/EmailService.java
+++ b/src/main/java/com/epam/ta/reportportal/util/email/EmailService.java
@@ -41,7 +41,6 @@ import com.epam.ta.reportportal.model.user.CreateUserRQFull;
 import com.epam.ta.reportportal.util.UserUtils;
 import com.epam.ta.reportportal.util.email.constant.IssueRegexConstant;
 import com.google.common.annotations.VisibleForTesting;
-
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,7 +54,6 @@ import java.util.stream.Collectors;
 import javax.mail.MessagingException;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
-
 import lombok.Setter;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -69,7 +67,7 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * Email Sending Service based on {@link JavaMailSender}
+ * Email Sending Service based on {@link JavaMailSender}.
  *
  * @author Andrei_Ramanchuk
  */
@@ -87,40 +85,17 @@ public class EmailService extends JavaMailSenderImpl {
   private InternetAddress from;
   private String rpHost;
 
+  /**
+   * Constructs an EmailService with the specified JavaMail properties.
+   *
+   * @param javaMailProperties the properties for configuring the JavaMailSender
+   */
   public EmailService(Properties javaMailProperties) {
     super.setJavaMailProperties(javaMailProperties);
   }
 
   /**
-   * User creation confirmation email
-   *
-   * @param subject Letter's subject
-   * @param recipients Letter's recipients
-   * @param url ReportPortal URL
-   */
-  public void sendCreateUserConfirmationEmail(
-      final String subject, final String[] recipients, final String url) {
-    MimeMessagePreparator preparator =
-        mimeMessage -> {
-          MimeMessageHelper message = new MimeMessageHelper(mimeMessage, true, "utf-8");
-          message.setSubject(subject);
-          message.setTo(recipients);
-          setFrom(message);
-
-          Map<String, Object> email = new HashMap<>();
-          email.put("url", getUrl(url));
-          String text = templateEngine.merge("registration-template.ftl", email);
-          message.setText(text, true);
-
-          message.addInline("create-user.png", emailTemplateResource("create-user.png"));
-
-          attachSocialImages(message);
-        };
-    this.send(preparator);
-  }
-
-  /**
-   * Finish launch notification
+   * Finish launch notification.
    *
    * @param recipients List of recipients
    * @param project {@link Project}
@@ -289,7 +264,7 @@ public class EmailService extends JavaMailSenderImpl {
   }
 
   /**
-   * Restore password email
+   * Restore password email.
    *
    * @param subject Letter's subject
    * @param recipients Letter's recipients
@@ -370,9 +345,9 @@ public class EmailService extends JavaMailSenderImpl {
   }
 
   /**
-   * Sets the sender's email address. Check if the string contains "<" to determine if the email
-   * address is in the format "from <email>". If it is, create a new InternetAddress object with the
-   * email address. If it is not, create a new InternetAddress object with personal name only.
+   * Sets the sender's email address. Check if the string contains "&lt;" to determine if the email
+   * address is in the format "from &lt;email>". If it is, create a new InternetAddress object with
+   * the email address. If it is not, create a new InternetAddress object with personal name only.
    *
    * @param from the sender's email address
    */
@@ -388,7 +363,7 @@ public class EmailService extends JavaMailSenderImpl {
     }
   }
 
-  /** Builds FROM field If username is email, format will be "from \<email\>" */
+  /** Builds FROM field for the email message. */
   private void setFrom(MimeMessageHelper message)
       throws MessagingException, UnsupportedEncodingException {
     InternetAddress sender =
@@ -403,6 +378,34 @@ public class EmailService extends JavaMailSenderImpl {
    */
   public Optional<InternetAddress> getFrom() {
     return Optional.ofNullable(from);
+  }
+
+  /**
+   * User creation confirmation email.
+   *
+   * @param subject Letter's subject
+   * @param recipients Letter's recipients
+   * @param url ReportPortal URL
+   */
+  public void sendCreateUserConfirmationEmail(
+      final String subject, final String[] recipients, final String url) {
+    MimeMessagePreparator preparator =
+        mimeMessage -> {
+          MimeMessageHelper message = new MimeMessageHelper(mimeMessage, true, "utf-8");
+          message.setSubject(subject);
+          message.setTo(recipients);
+          setFrom(message);
+
+          Map<String, Object> email = new HashMap<>();
+          email.put("url", getUrl(url));
+          String text = templateEngine.merge("registration-template.ftl", email);
+          message.setText(text, true);
+
+          message.addInline("create-user.png", emailTemplateResource("create-user.png"));
+
+          attachSocialImages(message);
+        };
+    this.send(preparator);
   }
 
   /**
@@ -504,6 +507,11 @@ public class EmailService extends JavaMailSenderImpl {
             EmailService.class.getClassLoader().getResource(TEMPLATE_IMAGES_PREFIX + resource)));
   }
 
+  /**
+   * Sends an email notification to the user about their account self-deletion.
+   *
+   * @param recipient the recipient's email address
+   */
   public void sendAccountSelfDeletionNotification(String recipient) {
     MimeMessagePreparator preparator =
         mimeMessage -> {
@@ -524,6 +532,11 @@ public class EmailService extends JavaMailSenderImpl {
     this.send(preparator);
   }
 
+  /**
+   * Sends an email notification to the user about their account deletion by retention policy.
+   *
+   * @param recipient the recipient's email address
+   */
   public void sendAccountDeletionByRetentionNotification(String recipient) {
     MimeMessagePreparator preparator =
         mimeMessage -> {
@@ -544,6 +557,11 @@ public class EmailService extends JavaMailSenderImpl {
     this.send(preparator);
   }
 
+  /**
+   * Sends an email notification to the user about their account deletion by retention policy.
+   *
+   * @param recipient the recipient's email address
+   */
   public void sendUserExpirationNotification(String recipient, Map<String, Object> params) {
     MimeMessagePreparator preparator =
         mimeMessage -> {

--- a/src/main/java/com/epam/ta/reportportal/util/email/EmailService.java
+++ b/src/main/java/com/epam/ta/reportportal/util/email/EmailService.java
@@ -368,7 +368,7 @@ public class EmailService extends JavaMailSenderImpl {
    * it will be set from username.
    */
   private void setFrom(MimeMessageHelper message)
-      throws MessagingException, UnsupportedEncodingException {
+      throws MessagingException {
     if (getFrom().isPresent()) {
       message.setFrom(getFrom().get());
     } else if (UserUtils.isEmailValid(getUsername())) {
@@ -377,17 +377,13 @@ public class EmailService extends JavaMailSenderImpl {
   }
 
   /**
-   * Gets the sender's email address. If sender is not set, it will be set from username.
+   * Gets the sender's email address.
    *
-   * @return the sender's email address
+   * @return the sender's email address if it is set.
+   * @see InternetAddress
    */
-  public Optional<InternetAddress> getFrom() throws UnsupportedEncodingException {
-    if (from != null) {
-      return Optional.of(from);
-    } else if (UserUtils.isEmailValid(getUsername())) {
-      return Optional.of(new InternetAddress(getUsername(), null));
-    }
-    return Optional.empty();
+  public Optional<InternetAddress> getFrom() {
+    return Optional.ofNullable(from);
   }
 
   /**
@@ -456,13 +452,12 @@ public class EmailService extends JavaMailSenderImpl {
    *
    * @param isCreated - flag that indicates if integration was created or updated. Used to determine
    *     email subject.
-   * @throws AddressException - if email address is not valid.
-   * @throws UnsupportedEncodingException - if email address is not valid.
+   * @throws AddressException - if email address is not valid or not exist.
    */
   public void sendConnectionTestEmail(boolean isCreated)
-      throws AddressException, UnsupportedEncodingException {
+      throws AddressException {
     InternetAddress sender =
-        getFrom().orElseThrow(() -> new AddressException("Email address is not valid"));
+        getFrom().orElseThrow(() -> new AddressException("Sender email address is not exist"));
     String subject =
         isCreated ? "Email server integration creation" : "Email server integration updated";
     MimeMessagePreparator preparator =


### PR DESCRIPTION
Change SMTP integration logic:

- For SMTP we use a value from the from field. We don't use a username for it.
- For sending a test connection email we use an address from the from field.
- For old integrations, keep using the username if a from value is not valid or exists.