### PR TITLE
EPMRPP-100435 || fix transactions order

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/project/impl/DeleteProjectHandlerImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/project/impl/DeleteProjectHandlerImpl.java
@@ -206,13 +206,13 @@ public class DeleteProjectHandlerImpl implements DeleteProjectHandler {
         project.getProjectIssueTypes().stream().map(ProjectIssueType::getIssueType)
             .filter(issueType -> !defaultIssueTypeIds.contains(issueType.getId()))
             .collect(Collectors.toSet());
-    projectContentRemover.remove(project);
     projectRepository.delete(project);
     issueTypeRepository.deleteAll(issueTypesToRemove);
     logIndexer.deleteIndex(project.getId());
     analyzerServiceClient.removeSuggest(project.getId());
     logRepository.deleteByProjectId(project.getId());
     attachmentBinaryDataService.deleteAllByProjectId(project.getId());
+    projectContentRemover.remove(project);
 
     return new OperationCompletionRS(
         "Project with id = '" + project.getId() + "' has been successfully deleted.");


### PR DESCRIPTION
The change reorders the call to `projectContentRemover.remove(project)` to occur after several other operations have been completed.