### PR TITLE
Refactor plugin uploader to use file extensions instead of content types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,6 @@ test {
     }
 }
 
-compileJava.dependsOn tasks.named('updateApiSubmodule')
 compileJava.dependsOn tasks.named('openApiGenerate')
 compileJava.dependsOn tasks.named('downloadManifestSchema')
 publish.dependsOn build

--- a/src/main/java/com/epam/ta/reportportal/core/integration/plugin/impl/CreatePluginHandlerImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/plugin/impl/CreatePluginHandlerImpl.java
@@ -28,6 +28,7 @@ import com.epam.ta.reportportal.model.EntryCreatedRS;
 import com.epam.ta.reportportal.model.activity.PluginActivityResource;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
@@ -65,12 +66,13 @@ public class CreatePluginHandlerImpl implements CreatePluginHandler {
   public EntryCreatedRS uploadPlugin(MultipartFile pluginFile, ReportPortalUser user) {
 
     String newPluginFileName = pluginFile.getOriginalFilename();
+    String extension = FilenameUtils.getExtension(newPluginFileName);
 
     BusinessRule.expect(newPluginFileName, StringUtils::isNotBlank)
         .verify(ErrorType.BAD_REQUEST_ERROR, "File name should be not empty.");
 
     try (InputStream inputStream = pluginFile.getInputStream()) {
-      var uploader = pluginUploaderFactory.getUploader(pluginFile.getContentType());
+      var uploader = pluginUploaderFactory.getUploader(extension);
       IntegrationType integrationType = uploader.uploadPlugin(newPluginFileName, inputStream);
       PluginActivityResource pluginActivityResource = new PluginActivityResource();
       pluginActivityResource.setId(integrationType.getId());

--- a/src/main/java/com/epam/ta/reportportal/core/integration/plugin/strategy/PluginUploaderFactory.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/plugin/strategy/PluginUploaderFactory.java
@@ -48,23 +48,23 @@ public class PluginUploaderFactory {
       JarPluginUploader jarPluginUploader,
       JsonPluginUploader jsonPluginUploader
   ) {
-    uploads.put("application/java-archive", jarPluginUploader);
-    uploads.put("application/jar", jarPluginUploader);
-    uploads.put("application/json", jsonPluginUploader);
+    uploads.put("jar", jarPluginUploader);
+    uploads.put("zip", jarPluginUploader);
+    uploads.put("json", jsonPluginUploader);
   }
 
   /**
    * Retrieves the appropriate {@link PluginUploader} based on the provided content type.
    *
-   * @param contentType The content type of the plugin to be uploaded
+   * @param extension The content type of the plugin to be uploaded
    * @return An instance of {@link PluginUploader} that matches the content type
    * @throws ReportPortalException if no uploader is found for the specified content type
    */
-  public PluginUploader getUploader(String contentType) {
-    return Optional.ofNullable(uploads.get(contentType))
+  public PluginUploader getUploader(String extension) {
+    return Optional.ofNullable(uploads.get(extension))
         .orElseThrow(() -> new ReportPortalException(
             ErrorType.PLUGIN_UPLOAD_ERROR,
-            "Unsupported content type: " + contentType
+            "Unsupported extension type: " + extension
         ));
   }
 }

--- a/src/test/java/com/epam/ta/reportportal/core/integration/plugin/impl/strategy/PluginUploaderFactoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/core/integration/plugin/impl/strategy/PluginUploaderFactoryTest.java
@@ -49,13 +49,13 @@ public class PluginUploaderFactoryTest {
 
   @Test
   void shouldReturnJarUploaderForJarContentType() {
-    PluginUploader result = factory.getUploader("application/java-archive");
+    PluginUploader result = factory.getUploader("jar");
     assertEquals(jarPluginUploader, result);
   }
 
   @Test
   void shouldReturnJsonUploaderForJsonContentType() {
-    PluginUploader result = factory.getUploader("application/json");
+    PluginUploader result = factory.getUploader("json");
     assertEquals(jsonPluginUploader, result);
   }
 
@@ -63,7 +63,7 @@ public class PluginUploaderFactoryTest {
   void shouldThrowExceptionForUnsupportedContentType() {
     ReportPortalException exception = assertThrows(
         ReportPortalException.class,
-        () -> factory.getUploader("unsupported/content-type")
+        () -> factory.getUploader("unsupported")
     );
 
     assertEquals(ErrorType.PLUGIN_UPLOAD_ERROR, exception.getErrorType());

--- a/src/test/java/com/epam/ta/reportportal/core/integration/plugin/strategy/PluginUploaderFactoryTest.java
+++ b/src/test/java/com/epam/ta/reportportal/core/integration/plugin/strategy/PluginUploaderFactoryTest.java
@@ -46,13 +46,13 @@ public class PluginUploaderFactoryTest {
 
   @Test
   void shouldReturnJarUploaderForJarContentType() {
-    PluginUploader result = factory.getUploader("application/java-archive");
+    PluginUploader result = factory.getUploader("jar");
     assertEquals(jarPluginUploader, result);
   }
 
   @Test
   void shouldReturnJsonUploaderForJsonContentType() {
-    PluginUploader result = factory.getUploader("application/json");
+    PluginUploader result = factory.getUploader("json");
     assertEquals(jsonPluginUploader, result);
   }
 
@@ -60,7 +60,7 @@ public class PluginUploaderFactoryTest {
   void shouldThrowExceptionForUnsupportedContentType() {
     ReportPortalException exception = assertThrows(
         ReportPortalException.class,
-        () -> factory.getUploader("unsupported/content-type")
+        () -> factory.getUploader("unsupported")
     );
 
     assertEquals(ErrorType.PLUGIN_UPLOAD_ERROR, exception.getErrorType());


### PR DESCRIPTION
This pull request refactors the plugin upload handling logic to use file extensions instead of MIME content types, simplifying the mapping of plugins to their respective uploaders. The changes include updates to the `PluginUploaderFactory` class, its methods, and related tests.

### Refactoring to use file extensions:

* **Updated `PluginUploaderFactory` to map file extensions instead of MIME content types**:
  - Replaced MIME type keys (e.g., `application/java-archive`) with file extensions (e.g., `jar`, `zip`, `json`) in the `uploads` map.
  - Modified the `getUploader` method to accept file extensions instead of content types and updated error messages accordingly.

* **Refactored `CreatePluginHandlerImpl` to extract file extensions**:
  - Added usage of `FilenameUtils.getExtension` to determine the file extension of the uploaded plugin.
  - Updated the call to `getUploader` to pass the extracted file extension instead of the content type.

### Test updates:

* **Updated unit tests in `PluginUploaderFactoryTest`**:
  - Adjusted test cases to use file extensions (e.g., `jar`, `json`) instead of MIME content types. [[1]](diffhunk://#diff-7210546264a2c2014d031be932dedd4c81595ee4d20020f4c68e61d4c4cb7b4cL52-R66) [[2]](diffhunk://#diff-883173326110007f16a79ecfa7fdc21a87ca3bf3ae1e6c62e4c85dc1a8b544dbL49-R63)
  - Updated the unsupported case to test against an unsupported extension instead of an unsupported MIME type.