### PR TITLE
Add support for binary data in plugin descriptor and details

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/integration/plugin/impl/PluginLoaderImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/plugin/impl/PluginLoaderImpl.java
@@ -101,6 +101,7 @@ public class PluginLoaderImpl implements PluginLoader {
         .developer(descriptor.getProvider())
         .metadata(descriptor.getMetadata())
         .properties(descriptor.getProperties())
+        .binaryData(descriptor.getBinaryData())
         .build();
     return new PluginInfo(descriptor.getPluginId(), descriptor.getVersion(), details);
   }

--- a/src/main/java/com/epam/ta/reportportal/core/plugin/PluginDetails.java
+++ b/src/main/java/com/epam/ta/reportportal/core/plugin/PluginDetails.java
@@ -47,6 +47,7 @@ public class PluginDetails implements Serializable {
   private final Map<String, Object> developer = new HashMap<>();
   private final Map<String, Object> metadata = new HashMap<>();
   private final Map<String, Object> properties = new HashMap<>();
+  private final Map<String, Object> binaryData = new HashMap<>();
 
   /**
    * Sets the developer information for the plugin.
@@ -284,6 +285,17 @@ public class PluginDetails implements Serializable {
      */
     public Builder properties(String key, Object value) {
       details.setProperties(key, value);
+      return this;
+    }
+
+    /**
+     * Sets the binary data for the plugin.
+     *
+     * @param binaryData a {@link Map} of binary data key-value pairs
+     * @return the builder instance
+     */
+    public Builder binaryData(Map<String, Object> binaryData) {
+      details.setProperties(binaryData);
       return this;
     }
 

--- a/src/main/java/com/epam/ta/reportportal/plugin/DetailPluginDescriptor.java
+++ b/src/main/java/com/epam/ta/reportportal/plugin/DetailPluginDescriptor.java
@@ -58,6 +58,7 @@ public class DetailPluginDescriptor implements PluginDescriptor {
   private final List<PluginDependency> dependencies = new ArrayList<>();
   private final Map<String, Object> metadata = new HashMap<>();
   private final Map<String, Object> properties = new HashMap<>();
+  private final Map<String, Object> binaryData = new HashMap<>();
 
   /**
    * Sets the plugin ID.
@@ -135,6 +136,29 @@ public class DetailPluginDescriptor implements PluginDescriptor {
   protected void setProperties(Map<String, Object> properties) {
     if (!properties.isEmpty()) {
       this.properties.putAll(properties);
+    }
+  }
+
+  /**
+   * Sets the binary data for the plugin.
+   *
+   * @param key   the binary data key
+   * @param value the binary data value
+   */
+  protected void setBinaryData(String key, Object value) {
+    if (key != null && !key.isEmpty()) {
+      this.binaryData.put(key, value);
+    }
+  }
+
+  /**
+   * Sets the binary data for the plugin.
+   *
+   * @param binaryData the binary data map
+   */
+  protected void setBinaryData(Map<String, Object> binaryData) {
+    if (!binaryData.isEmpty()) {
+      this.binaryData.putAll(binaryData);
     }
   }
 
@@ -311,6 +335,29 @@ public class DetailPluginDescriptor implements PluginDescriptor {
     }
 
     /**
+     * Sets the plugin binary data.
+     *
+     * @param key   the binary data key
+     * @param value the binary data value
+     * @return the current instance of {@link Builder}
+     */
+    public Builder binaryData(String key, Object value) {
+      descriptor.setBinaryData(key, value);
+      return this;
+    }
+
+    /**
+     * Sets the plugin binary data.
+     *
+     * @param binaryData the binary data map
+     * @return the current instance of {@link Builder}
+     */
+    public Builder binaryData(Map<String, Object> binaryData) {
+      binaryData.forEach(descriptor::setBinaryData);
+      return this;
+    }
+
+    /**
      * Builds the {@link DetailPluginDescriptor} instance.
      *
      * @return the built {@link DetailPluginDescriptor} instance
@@ -328,4 +375,6 @@ public class DetailPluginDescriptor implements PluginDescriptor {
   public static Builder builder() {
     return new Builder();
   }
+
+
 }


### PR DESCRIPTION
This pull request introduces support for handling binary data in plugin descriptors. The changes include updates to the `PluginDetails` and `DetailPluginDescriptor` classes, as well as modifications to the `DetailManifestPluginDescriptorFinder` to process binary data from plugin manifests.

### Support for binary data in plugin descriptors:

* `PluginDetails` class:
  - Added a new `binaryData` field to store binary data as a `Map<String, Object>`.
  - Introduced a `binaryData` method in the `Builder` class to allow setting binary data during plugin construction.

* `DetailPluginDescriptor` class:
  - Added a `binaryData` field to store binary data.
  - Added methods to set binary data either as individual key-value pairs or as a complete map. [[1]](diffhunk://#diff-9918090035b03a1044c433ea0dcb9c06f4702264ffe3e5e06281d5dbbcb215f1R142-R164) [[2]](diffhunk://#diff-9918090035b03a1044c433ea0dcb9c06f4702264ffe3e5e06281d5dbbcb215f1R337-R359)

### Updates to plugin descriptor creation:

* `DetailManifestPluginDescriptorFinder` class:
  - Introduced a `PLUGIN_BINARY_DATA_PREFIX` constant for binary data attributes in plugin manifests.
  - Refactored the `createPluginDescriptor` method to use a new utility method, `processAttributesByPrefix`, for extracting metadata, properties, and binary data from manifest attributes.
  - Added the `processAttributesByPrefix` method to streamline attribute processing based on a prefix.

### Minor changes:

* Added imports for `Attributes` and `StringUtils` in `DetailManifestPluginDescriptorFinder`. [[1]](diffhunk://#diff-c0cadfc9e974d981d98af446c5cd43260972c4687292987c93afb18b6c59bda9R25) [[2]](diffhunk://#diff-c0cadfc9e974d981d98af446c5cd43260972c4687292987c93afb18b6c59bda9R35)