### PR TITLE
Remove explicit volume for /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ ENV APP_DIR=/usr/app
 ENV JAVA_OPTS="-Xmx1g -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=70 -Djava.security.egd=file:/dev/./urandom "
 WORKDIR $APP_DIR
 COPY --from=build $APP_DIR/build/libs/service-api-*exec.jar .
-VOLUME ["/tmp"]
 EXPOSE 8080
 # ENTRYPOINT exec java ${JAVA_OPTS} -jar ${APP_DIR}/service-api-*exec.jar
 ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar ${APP_DIR}/service-api-*exec.jar"]


### PR DESCRIPTION
If not mounted explicitly, it creates an anonymous volume which is not deleted automatically when the container is deleted.