### PR TITLE
Refactor plugin data handling to include optional metadata, properties, and binary data

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/integration/plugin/impl/PluginLoaderImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/integration/plugin/impl/PluginLoaderImpl.java
@@ -206,9 +206,15 @@ public class PluginLoaderImpl implements PluginLoader {
     details.put("description", descriptor.getPluginDescription());
     details.put("documentation", descriptor.getDocumentation());
     details.put("requires", descriptor.getRequires());
-    details.put("metadata", descriptor.getMetadata());
-    details.put("properties", descriptor.getProperties());
-    details.put("binaryData", descriptor.getBinaryData());
+    Optional.ofNullable(descriptor.getMetadata())
+        .filter(metadata -> !metadata.isEmpty())
+        .ifPresent(metadata -> details.put("metadata", metadata));
+    Optional.ofNullable(descriptor.getProperties())
+        .filter(props -> !props.isEmpty())
+        .ifPresent(props -> details.put("properties", props));
+    Optional.ofNullable(descriptor.getBinaryData())
+        .filter(binaryData -> !binaryData.isEmpty())
+        .ifPresent(binaryData -> details.put("binaryData", binaryData));
 
     var developer = new HashMap<String, Object>();
     developer.put("name", descriptor.getProvider());


### PR DESCRIPTION
This pull request refines the `convertToDetails` method in `PluginLoaderImpl.java` to improve null safety and avoid adding empty values to the `details` map. The most important change is the replacement of direct `put` calls with conditional checks using `Optional` to ensure only non-empty values are added.

Code improvements for null safety and data validation:

* [`src/main/java/com/epam/ta/reportportal/core/integration/plugin/impl/PluginLoaderImpl.java`](diffhunk://#diff-5f61342761b599a9496cb199ad40426c77b79ade6134cc564979f3e09a3c18e9L209-R217): Updated the `convertToDetails` method to use `Optional.ofNullable` with `filter` to check for non-empty values before adding `metadata`, `properties`, and `binaryData` to the `details` map. This prevents null or empty values from being included.