### PR TITLE
Fix project groups permissions

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/ws/controller/GeneratedProjectController.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/controller/GeneratedProjectController.java
@@ -1,6 +1,7 @@
 package com.epam.ta.reportportal.ws.controller;
 
-import static com.epam.ta.reportportal.auth.permissions.Permissions.IS_ADMIN;
+import static com.epam.ta.reportportal.auth.permissions.Permissions.ALLOWED_TO_EDIT_PROJECT;
+import static com.epam.ta.reportportal.auth.permissions.Permissions.ALLOWED_TO_VIEW_PROJECT;
 
 import com.epam.reportportal.api.ProjectsApi;
 import com.epam.reportportal.api.model.AddProjectToGroupByIdRequest;
@@ -37,7 +38,7 @@ public class GeneratedProjectController implements ProjectsApi {
   }
 
   @Override
-  @PreAuthorize(IS_ADMIN)
+  @PreAuthorize(ALLOWED_TO_VIEW_PROJECT)
   public ResponseEntity<ProjectGroupsPage> getGroupsOfProject(
       String projectKey,
       Integer offset,
@@ -48,7 +49,7 @@ public class GeneratedProjectController implements ProjectsApi {
   }
 
   @Override
-  @PreAuthorize(IS_ADMIN)
+  @PreAuthorize(ALLOWED_TO_VIEW_PROJECT)
   public ResponseEntity<ProjectGroupInfo> getProjectGroupById(String projectKey, Long groupId) {
     var group = getGroupExtension().getProjectGroupById(projectKey, groupId).orElseThrow(
         () -> new ResponseStatusException(HttpStatus.NOT_FOUND)
@@ -57,7 +58,7 @@ public class GeneratedProjectController implements ProjectsApi {
   }
 
   @Override
-  @PreAuthorize(IS_ADMIN)
+  @PreAuthorize(ALLOWED_TO_EDIT_PROJECT)
   public ResponseEntity<SuccessfulUpdate> addGroupToProjectById(
       String projectKey,
       Long groupId,
@@ -68,7 +69,7 @@ public class GeneratedProjectController implements ProjectsApi {
   }
 
   @Override
-  @PreAuthorize(IS_ADMIN)
+  @PreAuthorize(ALLOWED_TO_EDIT_PROJECT)
   public ResponseEntity<Void> deleteGroupFromProjectById(String projectName, Long groupId) {
     getGroupExtension().deleteGroupFromProject(projectName, groupId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/src/main/java/com/epam/ta/reportportal/ws/controller/GroupController.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/controller/GroupController.java
@@ -19,7 +19,6 @@ package com.epam.ta.reportportal.ws.controller;
 import static com.epam.ta.reportportal.auth.permissions.Permissions.ALLOWED_TO_EDIT_GROUP;
 import static com.epam.ta.reportportal.auth.permissions.Permissions.IS_ADMIN;
 
-
 import com.epam.reportportal.api.GroupsApi;
 import com.epam.reportportal.api.model.AddProjectToGroupByIdRequest;
 import com.epam.reportportal.api.model.CreateGroupRequest;
@@ -31,7 +30,6 @@ import com.epam.reportportal.api.model.GroupUserInfo;
 import com.epam.reportportal.api.model.GroupUsersPage;
 import com.epam.reportportal.api.model.SuccessfulUpdate;
 import com.epam.reportportal.api.model.UpdateGroupRequest;
-import com.epam.ta.reportportal.auth.permissions.GroupEditorPermission;
 import com.epam.ta.reportportal.commons.ReportPortalUser;
 import com.epam.ta.reportportal.core.group.GroupExtensionPoint;
 import org.pf4j.PluginManager;


### PR DESCRIPTION
This pull request introduces updates to permission annotations in the `GeneratedProjectController` and `GroupController` classes, along with a submodule update in the `api-registry`. The key changes include replacing the `IS_ADMIN` permission with more granular permissions and updating the submodule reference.

### Permission Updates in Controllers:

* `GeneratedProjectController.java`:
  - Replaced `@PreAuthorize(IS_ADMIN)` with `@PreAuthorize(ALLOWED_TO_VIEW_PROJECT)` for the `getGroupsOfProject` and `getProjectGroupById` methods, enabling view-level permissions. [[1]](diffhunk://#diff-f9b98e7f1fab8d2c605175eab01c8648abbad4416bcddbdfbecfd383d8a1d47bL40-R41) [[2]](diffhunk://#diff-f9b98e7f1fab8d2c605175eab01c8648abbad4416bcddbdfbecfd383d8a1d47bL51-R52)
  - Replaced `@PreAuthorize(IS_ADMIN)` with `@PreAuthorize(ALLOWED_TO_EDIT_PROJECT)` for the `addGroupToProjectById` and `deleteGroupFromProjectById` methods, enabling edit-level permissions. [[1]](diffhunk://#diff-f9b98e7f1fab8d2c605175eab01c8648abbad4416bcddbdfbecfd383d8a1d47bL60-R61) [[2]](diffhunk://#diff-f9b98e7f1fab8d2c605175eab01c8648abbad4416bcddbdfbecfd383d8a1d47bL71-R72)
  - Updated import statements to include `ALLOWED_TO_EDIT_PROJECT` and `ALLOWED_TO_VIEW_PROJECT` permissions.

* `GroupController.java`:
  - Removed an unused import for `GroupEditorPermission` to clean up the code.

### Submodule Update:

* Updated the `api-registry` submodule to a new commit (`c11d8d86d61568449d6c6335a756bb6cbdafb386`).