### PR TITLE
Refactor build.gradle to use version catalog for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,15 +15,12 @@
  */
 
 plugins {
-    id 'io.spring.dependency-management' version '1.1.7'
-    id 'java'
-    id 'java-library'
-    id 'org.owasp.dependencycheck' version '11.1.1'
-    id 'org.springframework.boot' version "${springBootVersion}"
-    id "com.epam.drill.integration.cicd" version "0.1.6"
-    id "org.openapi.generator" version "7.11.0"
+    alias(libs.plugins.java.library)
+    alias(libs.plugins.owasp.dependencycheck)
+    alias(libs.plugins.drill.integration)
+    alias(libs.plugins.openapi.generator)
+    alias(libs.plugins.spring.boot)
 }
-
 
 import org.owasp.dependencycheck.reporting.ReportGenerator
 
@@ -34,14 +31,9 @@ apply from: "$scriptsUrl/release-service.gradle"
 apply from: "$scriptsUrl/signing.gradle"
 apply from: "$scriptsUrl/copy-database-scripts.gradle"
 
-project.hasProperty('sealightsSession') && sealightsSession?.trim() ? apply(from: 'sealights.gradle') : println('No sealights session')
-
-repositories {
-    if (!releaseMode) {
-        maven { url 'https://jitpack.io' }
-    }
-    mavenCentral { url "https://repo1.maven.org/maven2" }
-}
+project.hasProperty('sealightsSession') && sealightsSession?.trim() ?
+        apply(from: 'sealights.gradle') :
+        println('No sealights session')
 
 java {
     targetCompatibility = JavaVersion.VERSION_21
@@ -50,108 +42,65 @@ java {
     }
 }
 
-ext['spring-boot.version'] = "${springBootVersion}"
-
-dependencyManagement {
-    imports {
-        mavenBom(releaseMode ? 'com.epam.reportportal:commons-bom:' + '5.13.4' : 'com.epam.reportportal:commons-bom:5.13.4')
-        mavenBom('io.zonky.test.postgres:embedded-postgres-binaries-bom:16.2.0')
-        mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
-    }
-}
-
 println("Release mode: $releaseMode")
+
 dependencies {
     if (releaseMode) {
         println("Using release dependencies")
-        implementation 'com.epam.reportportal:commons'
-        implementation 'com.epam.reportportal:commons-dao'
-        implementation 'com.epam.reportportal:plugin-api'
+        implementation(libs.bundles.reportportal)
     } else {
         println("Using snapshot dependencies")
-        implementation 'com.github.reportportal:commons:75fcf17'
-        implementation 'com.github.reportportal:commons-dao:de4c71f'
-        implementation 'com.github.reportportal:plugin-api:73594bc'
+        implementation(libs.bundles.reportportal.dev)
     }
-    implementation 'jakarta.servlet:jakarta.servlet-api:6.1.0'
+    api(platform(libs.spring.boot.bom))
+    implementation(platform(libs.reportportal.commons.bom))
+    implementation(platform(libs.zonky.postgres.bom))
+    implementation(libs.bundles.spring.boot.starters)
+    implementation(libs.bundles.spring.security)
 
-    implementation 'org.springframework.boot:spring-boot-starter-aop'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-quartz'
-    implementation 'org.springframework.boot:spring-boot-starter-freemarker'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-amqp'
-    implementation 'org.springframework.boot:spring-boot-starter-batch'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    // MultipartFileUtils requires org.springframework.mock.web.MockMultipartFile
+    // TODO: implement own MultipartFile class
+    implementation(libs.spring.test)
 
-    implementation 'org.springframework.security:spring-security-acl'
-    implementation 'org.springframework.security:spring-security-core'
-    implementation 'org.springframework.security:spring-security-oauth2-core'
-    implementation 'org.springframework.security:spring-security-oauth2-client'
-    implementation 'org.springframework.security:spring-security-oauth2-resource-server'
-    implementation 'org.springframework.security:spring-security-web'
-    implementation 'org.springframework:spring-context-support'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
-
-    //Fix CVE-2025-24813
-    implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.40'
-    implementation 'org.apache.tomcat.embed:tomcat-embed-el:10.1.40'
-    implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.40'
-
-
-    implementation 'com.opencsv:opencsv:5.10'
-    implementation "org.jooq:jooq:${jooqVersion}"
-    implementation 'com.github.slugify:slugify:3.0.7'
+    implementation(libs.springdoc.openapi)
+    implementation(libs.opencsv)
+    implementation(libs.jooq)
+    implementation(libs.slugify)
 
     // Optional for spring-boot-starter-amqp
-    implementation "com.rabbitmq:http-client:5.3.0"
-    implementation("org.apache.httpcomponents.client5:httpclient5:5.4.3") // supports gzip encoding
+    implementation(libs.rabbitmq.http.client)
+    implementation(libs.httpclient5) // supports gzip encoding
 
-    // check authentication error response format for versions higher than 6.21.3
-    implementation('net.sf.jasperreports:jasperreports:6.21.3') { //TODO: consider upgrade to 7.0.1+
+    // Check authentication error response format for versions higher than 6.21.3 TODO: consider upgrade to 7.0.1+
+    implementation(libs.jasperreports) {
         exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-xml'
     }
+
     // JasperReport's export to XLS uses Apache POI and openpdf for PDF export
-    implementation 'org.apache.poi:poi:5.4.0'
-    implementation 'com.github.librepdf:openpdf:2.0.3'
-
-    implementation 'jakarta.inject:jakarta.inject-api:2.0.1'
-    implementation 'com.sun.mail:jakarta.mail:2.0.1'
-
-    implementation 'xerces:xercesImpl:2.12.2'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
-    implementation 'com.google.api-client:google-api-client:2.6.0'
-
-    implementation('commons-validator:commons-validator:1.9.0') {
+    implementation(libs.apache.poi)
+    implementation(libs.openpdf)
+    implementation(libs.jakarta.inject.api)
+    implementation(libs.jakarta.mail)
+    implementation(libs.xerces)
+    implementation(libs.bouncycastle)
+    implementation(libs.google.api.client)
+    implementation(libs.commons.validator) {
         exclude group: 'commons-beanutils', module: 'commons-beanutils'
     }
-    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation(libs.caffeine)
+    implementation(libs.apache.jclouds.filesystem)
+    implementation(libs.apache.commons.compress)
+    implementation(libs.hibernate.validator)
+    implementation(libs.json.schema.validator)
 
-    implementation "org.apache.jclouds.api:filesystem:${jcloudsVersion}"
-    implementation 'org.apache.commons:commons-compress:1.27.1'
-
-    implementation "org.hibernate.validator:hibernate-validator:${hibernateValidatorVersion}"
-
-    implementation 'com.networknt:json-schema-validator:1.5.6'
-
-    implementation 'com.github.slugify:slugify:3.0.7'
-
-    // add lombok support
-    compileOnly "org.projectlombok:lombok:${lombokVersion}"
-    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
-    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
-    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    // Add lombok support
+    compileOnly(libs.lombok)
+    annotationProcessor(libs.lombok)
 
     //  Tests
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.springframework:spring-web'
-    implementation 'org.springframework:spring-test'
-    testImplementation 'org.flywaydb.flyway-test-extensions:flyway-spring-test:10.0.0'
-
-    testImplementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
-    testImplementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+    testImplementation(libs.bundles.test.libs)
+    testCompileOnly(libs.lombok)
+    testAnnotationProcessor(libs.lombok)
 }
 
 sourceSets {
@@ -161,7 +110,6 @@ sourceSets {
         }
     }
 }
-
 
 openApiGenerate {
     generatorName.set("spring")
@@ -209,14 +157,13 @@ tasks.register('downloadManifestSchema') {
 }
 
 dependencyCheck {
-    formats = [ReportGenerator.Format.HTML, ReportGenerator.Format.XML]
+    formats = [ReportGenerator.Format.HTML, ReportGenerator.Format.XML] as List<String>
 //    cveValidForHours = 1
 }
 
 bootJar {
     duplicatesStrategy = duplicatesStrategy.EXCLUDE
-    project.hasProperty('gcp') ? getArchiveFileName().set('app.jar') : archiveClassifier.set('' +
-            'exec')
+    project.hasProperty('gcp') ? getArchiveFileName().set('app.jar') : archiveClassifier.set('' + 'exec')
 }
 jar.enabled(true)
 jar.archiveClassifier.set('')

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,3 @@ dockerJavaOptsDev=-DLOG_FILE=app.log \
                   -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
 dockerServerUrl=unix:///var/run/docker.sock
 org.gradle.jvmargs=-Xmx2048m
-lombokVersion=1.18.36
-springBootVersion=3.4.4
-jooqVersion=3.19.18
-hibernateValidatorVersion=8.0.2.Final
-jcloudsVersion=2.6.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,11 +86,11 @@ xerces = { group = "xerces", name = "xercesImpl", version.ref = "xerces" }
 bouncycastle = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
 google-api-client = { group = "com.google.api-client", name = "google-api-client", version.ref = "google-api-client" }
 commons-validator = { group = "commons-validator", name = "commons-validator", version.ref = "commons-validator" }
-caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine" }
 apache-jclouds-filesystem = { group = "org.apache.jclouds.api", name = "filesystem", version.ref = "jclouds" }
 apache-commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "apache-commons-compress" }
 hibernate-validator = { group = "org.hibernate.validator", name = "hibernate-validator", version.ref = "hibernate-validator" }
 json-schema-validator = { group = "com.networknt", name = "json-schema-validator", version.ref = "json-schema-validator" }
+caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine" }
 
 # Lombok
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,137 @@
+[versions]
+# Development versions
+commons-dev = "75fcf17"
+commons-dao-dev = "de4c71f"
+plugin-api-dev = "73594bc"
+
+# Platform versions
+commons-bom = "5.13.4"
+spring-boot = "3.4.6"
+zonky-postgres-bom = "16.2.0"
+
+# Plugin versions
+owasp-dependencycheck = "11.1.1"
+drill-integration = "0.1.6"
+openapi-generator = "7.11.0"
+
+# Library versions
+springdoc-openapi = "2.8.8"
+opencsv = "5.10"
+rabbitmq-http = "5.3.0"
+httpclient5 = "5.4.3"
+jasperreports = "6.21.3"
+apache-poi = "5.4.0"
+openpdf = "2.0.3"
+jakarta-inject = "2.0.1"
+jakarta-mail = "2.0.1"
+xerces = "2.12.2"
+bouncycastle = "1.80"
+google-api-client = "2.6.0"
+commons-validator = "1.9.0"
+apache-commons-compress = "1.27.1"
+json-schema-validator = "1.5.6"
+slugify = "3.0.7"
+flyway-spring-test = "10.0.0"
+jjwt = "0.12.5"
+lombok = "1.18.36"
+jooq = "3.19.18"
+jclouds = "2.6.0"
+hibernate-validator = "8.0.2.Final"
+
+[libraries]
+# Development libs
+reportportal-commons-dev = { group = "com.github.reportportal", name = "commons", version.ref = "commons-dev" }
+reportportal-commons-dao-dev = { group = "com.github.reportportal", name = "commons-dao", version.ref = "commons-dao-dev" }
+reportportal-plugin-api-dev = { group = "com.github.reportportal", name = "plugin-api", version.ref = "plugin-api-dev" }
+
+# Production libs
+reportportal-commons = { group = "com.epam.reportportal", name = "commons" }
+reportportal-commons-dao = { group = "com.epam.reportportal", name = "commons-dao" }
+reportportal-plugin-api = { group = "com.epam.reportportal", name = "plugin-api" }
+
+# Platforms
+spring-boot-bom = { group = "org.springframework.boot", name = "spring-boot-dependencies", version.ref = "spring-boot" }
+reportportal-commons-bom = { group = "com.epam.reportportal", name = "commons-bom", version.ref = "commons-bom" }
+zonky-postgres-bom = { group = "io.zonky.test.postgres", name = "embedded-postgres-binaries-bom", version.ref = "zonky-postgres-bom" }
+
+# Spring Boot
+spring-boot-starter-aop = { group = "org.springframework.boot", name = "spring-boot-starter-aop" }
+spring-boot-starter-web = { group = "org.springframework.boot", name = "spring-boot-starter-web" }
+spring-boot-starter-quartz = { group = "org.springframework.boot", name = "spring-boot-starter-quartz" }
+spring-boot-starter-freemarker = { group = "org.springframework.boot", name = "spring-boot-starter-freemarker" }
+spring-boot-starter-actuator = { group = "org.springframework.boot", name = "spring-boot-starter-actuator" }
+spring-boot-starter-amqp = { group = "org.springframework.boot", name = "spring-boot-starter-amqp" }
+spring-boot-starter-batch = { group = "org.springframework.boot", name = "spring-boot-starter-batch" }
+spring-boot-starter-security = { group = "org.springframework.boot", name = "spring-boot-starter-security" }
+spring-boot-starter-oauth2-client = { group = "org.springframework.boot", name = "spring-boot-starter-oauth2-client" }
+spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test" }
+
+# Spring Security
+spring-security-acl = { group = "org.springframework.security", name = "spring-security-acl" }
+spring-security-oauth2-resource-server = { group = "org.springframework.security", name = "spring-security-oauth2-resource-server" }
+
+# Other libraries
+springdoc-openapi = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc-openapi" }
+opencsv = { group = "com.opencsv", name = "opencsv", version.ref = "opencsv" }
+jooq = { group = "org.jooq", name = "jooq", version.ref = "jooq" }
+slugify = { group = "com.github.slugify", name = "slugify", version.ref = "slugify" }
+rabbitmq-http-client = { group = "com.rabbitmq", name = "http-client", version.ref = "rabbitmq-http" }
+httpclient5 = { group = "org.apache.httpcomponents.client5", name = "httpclient5", version.ref = "httpclient5" }
+jasperreports = { group = "net.sf.jasperreports", name = "jasperreports", version.ref = "jasperreports" }
+apache-poi = { group = "org.apache.poi", name = "poi", version.ref = "apache-poi" }
+openpdf = { group = "com.github.librepdf", name = "openpdf", version.ref = "openpdf" }
+jakarta-inject-api = { group = "jakarta.inject", name = "jakarta.inject-api", version.ref = "jakarta-inject" }
+jakarta-mail = { group = "com.sun.mail", name = "jakarta.mail", version.ref = "jakarta-mail" }
+xerces = { group = "xerces", name = "xercesImpl", version.ref = "xerces" }
+bouncycastle = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
+google-api-client = { group = "com.google.api-client", name = "google-api-client", version.ref = "google-api-client" }
+commons-validator = { group = "commons-validator", name = "commons-validator", version.ref = "commons-validator" }
+caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine" }
+apache-jclouds-filesystem = { group = "org.apache.jclouds.api", name = "filesystem", version.ref = "jclouds" }
+apache-commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "apache-commons-compress" }
+hibernate-validator = { group = "org.hibernate.validator", name = "hibernate-validator", version.ref = "hibernate-validator" }
+json-schema-validator = { group = "com.networknt", name = "json-schema-validator", version.ref = "json-schema-validator" }
+
+# Lombok
+lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
+
+# Test libraries
+spring-test = { group = "org.springframework", name = "spring-test" }
+flyway-spring-test = { group = "org.flywaydb.flyway-test-extensions", name = "flyway-spring-test", version.ref = "flyway-spring-test" }
+jjwt-impl = { group = "io.jsonwebtoken", name = "jjwt-impl", version.ref = "jjwt" }
+jjwt-jackson = { group = "io.jsonwebtoken", name = "jjwt-jackson", version.ref = "jjwt" }
+
+[bundles]
+reportportal = ["reportportal-commons", "reportportal-commons-dao", "reportportal-plugin-api"]
+reportportal-dev = ["reportportal-commons-dev", "reportportal-commons-dao-dev", "reportportal-plugin-api-dev"]
+
+spring-boot-starters = [
+    "spring-boot-starter-aop",
+    "spring-boot-starter-web",
+    "spring-boot-starter-quartz",
+    "spring-boot-starter-freemarker",
+    "spring-boot-starter-actuator",
+    "spring-boot-starter-amqp",
+    "spring-boot-starter-batch",
+    "spring-boot-starter-security",
+    "spring-boot-starter-oauth2-client"
+]
+
+spring-security = [
+    "spring-security-acl",
+    "spring-security-oauth2-resource-server"
+]
+
+test-libs = [
+    "spring-boot-starter-test",
+    "flyway-spring-test",
+    "jjwt-impl",
+    "jjwt-jackson"
+]
+
+[plugins]
+java-library = { id = "java-library" }
+spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
+owasp-dependencycheck = { id = "org.owasp.dependencycheck", version.ref = "owasp-dependencycheck" }
+drill-integration = { id = "com.epam.drill.integration.cicd", version.ref = "drill-integration" }
+openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = 'service-api'
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven { url "https://jitpack.io" }
+    }
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+}


### PR DESCRIPTION
This pull request introduces significant changes to dependency management and versioning in the project. It centralizes dependency versions in a new `gradle/libs.versions.toml` file, removes hardcoded versions from `gradle.properties`, and updates the Gradle settings to enforce repository usage policies.

### Dependency Management Updates:

* **Centralized Dependency Versions**: Introduced a `gradle/libs.versions.toml` file to manage all dependency versions, including libraries, plugins, and platforms. This improves maintainability and ensures consistency across the project.
* **Removed Hardcoded Versions**: Removed hardcoded dependency versions (`lombokVersion`, `springBootVersion`, etc.) from `gradle.properties`, as these are now managed in the `libs.versions.toml` file.

### Gradle Configuration Enhancements:

* **Repository Management**: Updated `settings.gradle` to include `dependencyResolutionManagement` with Maven Central and JitPack repositories. Added a `FAIL_ON_PROJECT_REPOS` mode to enforce repository usage policies.