### PR TITLE
Refactor plugin upload logic to improve manifest persisting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,9 @@ dependencies {
         implementation 'com.epam.reportportal:plugin-api'
     } else {
         println("Using snapshot dependencies")
-        implementation 'com.github.reportportal:commons:fdfdcdf'
+        implementation 'com.github.reportportal:commons:fcee2e2'
         implementation 'com.github.reportportal:commons-dao:392eb1b'
-        implementation 'com.github.reportportal:plugin-api:1e34931'
+        implementation 'com.github.reportportal:plugin-api:f8e5bea'
     }
     implementation 'jakarta.servlet:jakarta.servlet-api:6.1.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
         println("Using snapshot dependencies")
         implementation 'com.github.reportportal:commons:fdfdcdf'
         implementation 'com.github.reportportal:commons-dao:392eb1b'
-        implementation 'com.github.reportportal:plugin-api:21310d8'
+        implementation 'com.github.reportportal:plugin-api:1e34931'
     }
     implementation 'jakarta.servlet:jakarta.servlet-api:6.1.0'
 

--- a/src/test/java/com/epam/ta/reportportal/plugin/JsonPluginUploaderTest.java
+++ b/src/test/java/com/epam/ta/reportportal/plugin/JsonPluginUploaderTest.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,17 +88,17 @@ public class JsonPluginUploaderTest {
     InputStream manifestStream = new ByteArrayInputStream(manifestJson.getBytes());
 
     IntegrationType mockIntegrationType = new IntegrationType();
-    when(integrationTypeRepository.save(any(IntegrationType.class))).thenReturn(
-        mockIntegrationType);
-    when(jsonSchemaValidator.validate(any(String.class), any(JsonNode.class))).thenReturn(
-        Collections.emptySet());
+    when(integrationTypeRepository.findByName(any())).thenReturn(Optional.empty());
+    when(integrationTypeRepository.saveAndFlush(any(IntegrationType.class))).thenReturn(mockIntegrationType);
+    when(jsonSchemaValidator.validate(any(String.class), any(JsonNode.class))).thenReturn(Collections.emptySet());
 
     IntegrationType result = jsonPluginUploader.uploadPlugin("manifest.json", manifestStream);
 
     assertNotNull(result, "Resulting IntegrationType should not be null");
-    verify(integrationTypeRepository).save(any(IntegrationType.class));
+    verify(integrationTypeRepository).findByName(any());
+    verify(integrationTypeRepository).saveAndFlush(any(IntegrationType.class));
     verify(jsonSchemaValidator).validate(any(String.class), any(JsonNode.class));
-    verify(integrationTypeRepository).save(argThat(type ->
+    verify(integrationTypeRepository).saveAndFlush(argThat(type ->
         type.getIntegrationGroup().name().equals("BTS")));
   }
 
@@ -141,14 +142,16 @@ public class JsonPluginUploaderTest {
     InputStream manifestStream = new ByteArrayInputStream(manifestJson.getBytes());
 
     IntegrationType mockIntegrationType = new IntegrationType();
-    when(integrationTypeRepository.save(any(IntegrationType.class)))
+    when(integrationTypeRepository.findByName(any())).thenReturn(Optional.empty());
+    when(integrationTypeRepository.saveAndFlush(any(IntegrationType.class)))
         .thenReturn(mockIntegrationType);
     when(jsonSchemaValidator.validate(any(String.class), any(JsonNode.class)))
         .thenReturn(Collections.emptySet());
 
     jsonPluginUploader.uploadPlugin("manifest.json", manifestStream);
 
-    verify(integrationTypeRepository).save(argThat(type ->
+    verify(integrationTypeRepository).findByName(any());
+    verify(integrationTypeRepository).saveAndFlush(argThat(type ->
         type.getIntegrationGroup().name().equals("OTHER")));
   }
 }


### PR DESCRIPTION
This pull request refactors the `JsonPluginUploader` class to adjust the plugin upload flow.

### Adjustments to plugin upload flow:

* **Improved handling of existing plugins:** The `uploadPlugin` method now checks if a plugin with the same name already exists in the repository. If it does, the plugin's ID is updated before saving, ensuring proper handling of updates. (`[src/main/java/com/epam/ta/reportportal/core/integration/plugin/strategy/JsonPluginUploader.javaL78-R82](diffhunk://#diff-3d194ff72d32e6c7815e79269308748d8aa4da603fe5a8a15792a4b131ac37b9L78-R82)`)