### PR TITLE
Set forward headers strategy to FRAMEWORK in application properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -101,7 +101,6 @@ server.port=8585
 server.forward-headers-strategy=FRAMEWORK
 server.servlet.context-path=/
 
-
 spring.servlet.multipart.max-file-size=128MB
 spring.servlet.multipart.max-request-size=128MB
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -98,7 +98,9 @@ spring.rabbitmq.addresses=\${rp.amqp.addresses}
 ## Spring server properties
 server.tomcat.connection-timeout=30s
 server.port=8585
+server.forward-headers-strategy=FRAMEWORK
 server.servlet.context-path=/
+
 
 spring.servlet.multipart.max-file-size=128MB
 spring.servlet.multipart.max-request-size=128MB


### PR DESCRIPTION
This pull request introduces a configuration update to the `application.properties` file to enhance server behavior. The most notable change is the addition of a new property to manage how forward headers are handled.

### Configuration Update:
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R101-R104): Added `server.forward-headers-strategy=FRAMEWORK` to configure the server to use the framework's default strategy for processing forwarded headers.