### PR TITLE
EPMRPP-107161 || Error types for plugin exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,14 +47,20 @@ println("Release mode: $releaseMode")
 dependencies {
     if (releaseMode) {
         println("Using release dependencies")
-        implementation(libs.bundles.reportportal)
+        implementation(libs.reportportal.commons)
+        implementation(libs.reportportal.commons.dao) {
+            exclude group: 'com.epam.reportportal', module: 'commons'
+        }
         implementation(libs.reportportal.plugin.api) {
             exclude group: 'com.epam.reportportal', module: 'commons-dao'
             exclude group: 'com.epam.reportportal', module: 'commons'
         }
     } else {
         println("Using snapshot dependencies")
-        implementation(libs.bundles.reportportal.dev)
+        implementation(libs.reportportal.commons.dev)
+        implementation(libs.reportportal.commons.dao.dev) {
+            exclude group: 'com.github.reportportal', module: 'commons'
+        }
         implementation(libs.reportportal.plugin.api.dev) {
             exclude group: 'com.github.reportportal', module: 'commons-dao'
             exclude group: 'com.github.reportportal', module: 'commons'

--- a/build.gradle
+++ b/build.gradle
@@ -49,13 +49,15 @@ dependencies {
         println("Using release dependencies")
         implementation(libs.bundles.reportportal)
         implementation(libs.reportportal.plugin.api) {
-            exclude group: 'com.github.reportportal', module: 'commons-dao'
+            exclude group: 'com.epam.reportportal', module: 'commons-dao'
+            exclude group: 'com.epam.reportportal', module: 'commons'
         }
     } else {
         println("Using snapshot dependencies")
         implementation(libs.bundles.reportportal.dev)
         implementation(libs.reportportal.plugin.api.dev) {
             exclude group: 'com.github.reportportal', module: 'commons-dao'
+            exclude group: 'com.github.reportportal', module: 'commons'
         }
     }
     api(platform(libs.spring.boot.bom))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,9 +103,6 @@ jjwt-impl = { group = "io.jsonwebtoken", name = "jjwt-impl", version.ref = "jjwt
 jjwt-jackson = { group = "io.jsonwebtoken", name = "jjwt-jackson", version.ref = "jjwt" }
 
 [bundles]
-reportportal = ["reportportal-commons", "reportportal-commons-dao"]
-reportportal-dev = ["reportportal-commons-dev", "reportportal-commons-dao-dev"]
-
 spring-boot-starters = [
     "spring-boot-starter-aop",
     "spring-boot-starter-web",

--- a/src/main/java/com/epam/ta/reportportal/core/organization/OrganizationExtensionPoint.java
+++ b/src/main/java/com/epam/ta/reportportal/core/organization/OrganizationExtensionPoint.java
@@ -20,9 +20,9 @@ import com.epam.reportportal.api.model.CreateOrganizationRequest;
 import com.epam.reportportal.api.model.OrganizationInfo;
 import com.epam.reportportal.api.model.UpdateOrganizationRequest;
 import com.epam.reportportal.extension.ReportPortalExtensionPoint;
+import com.epam.reportportal.rules.exception.ReportPortalException;
 import com.epam.ta.reportportal.commons.ReportPortalUser;
 import com.epam.ta.reportportal.entity.user.User;
-import org.jclouds.rest.ResourceNotFoundException;
 
 /**
  * Extension point for organization management in ReportPortal.
@@ -55,8 +55,9 @@ public interface OrganizationExtensionPoint extends ReportPortalExtensionPoint {
    * @param organizationId The ID of the organization to update.
    * @param updateRequest  The new details for the organization.
    * @param principal      The user performing the update operation.
+   * @throws ReportPortalException If the organization with the specified ID does not exist.
    */
-  void updateOrganization(Long organizationId, UpdateOrganizationRequest updateRequest, ReportPortalUser principal) throws ResourceNotFoundException;
+  void updateOrganization(Long organizationId, UpdateOrganizationRequest updateRequest, ReportPortalUser principal) throws ReportPortalException;
 
 
   /**
@@ -64,7 +65,7 @@ public interface OrganizationExtensionPoint extends ReportPortalExtensionPoint {
    *
    * @param organizationId The ID of the organization to retrieve.
    * @param principal      The user performing the delete operation.
-   * @throws ResourceNotFoundException If the organization with the specified ID does not exist.
+   * @throws ReportPortalException If the organization with the specified ID does not exist.
    */
-  void deleteOrganization(Long organizationId, ReportPortalUser principal) throws ResourceNotFoundException;
+  void deleteOrganization(Long organizationId, ReportPortalUser principal) throws ReportPortalException;
 }

--- a/src/main/java/com/epam/ta/reportportal/exception/rest/StatusCodeMapping.java
+++ b/src/main/java/com/epam/ta/reportportal/exception/rest/StatusCodeMapping.java
@@ -146,6 +146,8 @@ public class StatusCodeMapping {
 
       put(ErrorType.RETRIES_HANDLER_ERROR, HttpStatus.BAD_REQUEST);
 
+      put(ErrorType.PAYMENT_REQUIRED, HttpStatus.PAYMENT_REQUIRED);
+      put(ErrorType.PAID_PLUGIN_REQUIRED, HttpStatus.PAYMENT_REQUIRED);
     }
   };
 

--- a/src/main/java/com/epam/ta/reportportal/ws/controller/GeneratedProjectController.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/controller/GeneratedProjectController.java
@@ -8,6 +8,8 @@ import com.epam.reportportal.api.model.AddProjectToGroupByIdRequest;
 import com.epam.reportportal.api.model.ProjectGroupInfo;
 import com.epam.reportportal.api.model.ProjectGroupsPage;
 import com.epam.reportportal.api.model.SuccessfulUpdate;
+import com.epam.reportportal.rules.exception.ErrorType;
+import com.epam.reportportal.rules.exception.ReportPortalException;
 import com.epam.ta.reportportal.core.group.GroupExtensionPoint;
 import com.epam.ta.reportportal.core.plugin.Pf4jPluginBox;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Controller for handling project collection-related requests.
@@ -55,7 +56,7 @@ public class GeneratedProjectController implements ProjectsApi {
   @Transactional(readOnly = true)
   public ResponseEntity<ProjectGroupInfo> getProjectGroupById(String projectKey, Long groupId) {
     var group = getGroupExtension().getProjectGroupById(projectKey, groupId).orElseThrow(
-        () -> new ResponseStatusException(HttpStatus.NOT_FOUND)
+        () -> new ReportPortalException(ErrorType.NOT_FOUND, groupId)
     );
     return ResponseEntity.ok(group);
   }
@@ -82,8 +83,9 @@ public class GeneratedProjectController implements ProjectsApi {
 
   private GroupExtensionPoint getGroupExtension() {
     return pluginBox.getInstance(GroupExtensionPoint.class)
-        .orElseThrow(() -> new ResponseStatusException(
-            HttpStatus.PAYMENT_REQUIRED,
-            "Group management is not available. Please install the 'group' plugin."));
+        .orElseThrow(() -> new ReportPortalException(
+            ErrorType.PAID_PLUGIN_REQUIRED,
+            "Group", "Group management is not available"
+        ));
   }
 }

--- a/src/main/java/com/epam/ta/reportportal/ws/controller/GroupController.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/controller/GroupController.java
@@ -31,6 +31,8 @@ import com.epam.reportportal.api.model.GroupUserInfo;
 import com.epam.reportportal.api.model.GroupUsersPage;
 import com.epam.reportportal.api.model.SuccessfulUpdate;
 import com.epam.reportportal.api.model.UpdateGroupRequest;
+import com.epam.reportportal.rules.exception.ErrorType;
+import com.epam.reportportal.rules.exception.ReportPortalException;
 import com.epam.ta.reportportal.core.group.GroupExtensionPoint;
 import com.epam.ta.reportportal.core.plugin.Pf4jPluginBox;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +41,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Controller for handling group-related requests.
@@ -91,7 +92,7 @@ public class GroupController implements GroupsApi {
   @Transactional(readOnly = true)
   public ResponseEntity<GroupInfo> getGroupById(Long groupId) {
     GroupInfo group = getGroupExtension().getGroupById(groupId).orElseThrow(
-        () -> new ResponseStatusException(HttpStatus.NOT_FOUND)
+        () -> new ReportPortalException(ErrorType.NOT_FOUND, groupId)
     );
     return ResponseEntity.ok(group);
   }
@@ -132,7 +133,7 @@ public class GroupController implements GroupsApi {
   @Transactional(readOnly = true)
   public ResponseEntity<GroupUserInfo> getGroupUserById(Long groupId, Long userId) {
     var groupUserInfo = getGroupExtension().getGroupUserById(groupId, userId).orElseThrow(
-        () -> new ResponseStatusException(HttpStatus.NOT_FOUND)
+        () -> new ReportPortalException(ErrorType.NOT_FOUND, groupId)
     );
     return ResponseEntity.ok(groupUserInfo);
   }
@@ -171,7 +172,7 @@ public class GroupController implements GroupsApi {
   @Transactional(readOnly = true)
   public ResponseEntity<GroupProjectInfo> getGroupProjectById(Long groupId, Long projectId) {
     var groupProjectInfo = getGroupExtension().getGroupProjectById(groupId, projectId)
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        .orElseThrow(() -> new ReportPortalException(ErrorType.NOT_FOUND, groupId));
     return ResponseEntity.ok(groupProjectInfo);
   }
 
@@ -197,9 +198,9 @@ public class GroupController implements GroupsApi {
 
   private GroupExtensionPoint getGroupExtension() {
     return pluginBox.getInstance(GroupExtensionPoint.class)
-        .orElseThrow(() -> new ResponseStatusException(
-            HttpStatus.PAYMENT_REQUIRED,
-            "Group management is not available. Please install the 'group' plugin."
+        .orElseThrow(() -> new ReportPortalException(
+            ErrorType.PAID_PLUGIN_REQUIRED,
+            "Group", "Group management is not available"
         ));
   }
 }

--- a/src/main/java/com/epam/ta/reportportal/ws/controller/OrganizationController.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/controller/OrganizationController.java
@@ -60,7 +60,6 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
@@ -193,9 +192,9 @@ public class OrganizationController extends BaseController implements Organizati
 
   private OrganizationExtensionPoint getOrgExtension() {
     return pluginBox.getInstance(OrganizationExtensionPoint.class)
-        .orElseThrow(() -> new ResponseStatusException(
-            HttpStatus.PAYMENT_REQUIRED,
-            "Organization management is not available. Please install the 'organization' plugin."
+        .orElseThrow(() -> new ReportPortalException(
+            ErrorType.PAID_PLUGIN_REQUIRED,
+            "Organization", "Organization management is unavailable."
         ));
   }
 

--- a/src/main/java/com/epam/ta/reportportal/ws/controller/OrganizationGroupController.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/controller/OrganizationGroupController.java
@@ -25,6 +25,8 @@ import com.epam.reportportal.api.model.CreateOrgGroupRequest;
 import com.epam.reportportal.api.model.GroupInfo;
 import com.epam.reportportal.api.model.GroupPage;
 import com.epam.reportportal.api.model.OrgGroupPage;
+import com.epam.reportportal.rules.exception.ErrorType;
+import com.epam.reportportal.rules.exception.ReportPortalException;
 import com.epam.ta.reportportal.core.group.GroupExtensionPoint;
 import com.epam.ta.reportportal.core.plugin.Pf4jPluginBox;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +35,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Controller for handling organization group-related requests.
@@ -82,9 +83,9 @@ public class OrganizationGroupController implements OrganizationGroupsApi {
 
   private GroupExtensionPoint getGroupExtension() {
     return pluginBox.getInstance(GroupExtensionPoint.class)
-        .orElseThrow(() -> new ResponseStatusException(
-            HttpStatus.PAYMENT_REQUIRED,
-            "Group management is not available. Please install the 'group' plugin."
+        .orElseThrow(() -> new ReportPortalException(
+            ErrorType.PAID_PLUGIN_REQUIRED,
+            "Group", "Group management extension point"
         ));
   }
 


### PR DESCRIPTION
This pull request refactors error handling across several controllers and extension points in the codebase, standardizing the use of `ReportPortalException` and custom `ErrorType` enums instead of generic Spring exceptions. The changes improve consistency in error reporting, especially for cases involving missing resources and paid plugin requirements. Additionally, the HTTP status mapping is updated to support new error types related to payment requirements.

**Error handling standardization:**

* Replaced all usages of `ResponseStatusException` with `ReportPortalException`, passing in appropriate `ErrorType` values such as `NOT_FOUND` and `PAID_PLUGIN_REQUIRED` in controllers like `GroupController`, `GeneratedProjectController`, `OrganizationController`, and `OrganizationGroupController`. This ensures consistent error reporting for missing resources and plugin requirements. [[1]](diffhunk://#diff-f9b98e7f1fab8d2c605175eab01c8648abbad4416bcddbdfbecfd383d8a1d47bL58-R59) [[2]](diffhunk://#diff-6d87a2f17393752ec57ea121c3bc38092e754010a4916e5e7764bc6a27e7f219L94-R95) [[3]](diffhunk://#diff-6d87a2f17393752ec57ea121c3bc38092e754010a4916e5e7764bc6a27e7f219L135-R136) [[4]](diffhunk://#diff-6d87a2f17393752ec57ea121c3bc38092e754010a4916e5e7764bc6a27e7f219L174-R175) [[5]](diffhunk://#diff-6d87a2f17393752ec57ea121c3bc38092e754010a4916e5e7764bc6a27e7f219L200-R203) [[6]](diffhunk://#diff-d30e4157b0353b56364b6f6a75e66dbd2b069ce9bf7a1895089be7763da03ffeL196-R197) [[7]](diffhunk://#diff-c74798dd2eea440751fe1862bad6670f020da66d144c730a17a4c14c45d67f76L85-R88)

* Updated imports to remove unused `ResponseStatusException` and add `ReportPortalException` and `ErrorType` where needed in all affected controllers. [[1]](diffhunk://#diff-f9b98e7f1fab8d2c605175eab01c8648abbad4416bcddbdfbecfd383d8a1d47bR11-R12) [[2]](diffhunk://#diff-f9b98e7f1fab8d2c605175eab01c8648abbad4416bcddbdfbecfd383d8a1d47bL19) [[3]](diffhunk://#diff-6d87a2f17393752ec57ea121c3bc38092e754010a4916e5e7764bc6a27e7f219R34-R35) [[4]](diffhunk://#diff-6d87a2f17393752ec57ea121c3bc38092e754010a4916e5e7764bc6a27e7f219L42) [[5]](diffhunk://#diff-d30e4157b0353b56364b6f6a75e66dbd2b069ce9bf7a1895089be7763da03ffeL63) [[6]](diffhunk://#diff-c74798dd2eea440751fe1862bad6670f020da66d144c730a17a4c14c45d67f76R28-R29) [[7]](diffhunk://#diff-c74798dd2eea440751fe1862bad6670f020da66d144c730a17a4c14c45d67f76L36)

**Extension point interface updates:**

* Changed the `OrganizationExtensionPoint` interface to throw `ReportPortalException` instead of `ResourceNotFoundException` in the `updateOrganization` and `deleteOrganization` methods, updating the Javadoc accordingly. [[1]](diffhunk://#diff-1ae2ae9d8974aa75107c3237db5bda80aa3e9a52ac943d22925f87a15371275bR23-L25) [[2]](diffhunk://#diff-1ae2ae9d8974aa75107c3237db5bda80aa3e9a52ac943d22925f87a15371275bR58-R70)

**Error type and status code mapping:**

* Added new error types `PAYMENT_REQUIRED` and `PAID_PLUGIN_REQUIRED` to the `StatusCodeMapping`, mapping them to the HTTP status code `PAYMENT_REQUIRED`. This supports more granular error handling for paid plugin requirements.