### PR TITLE
EPMRPP-101051 || Fix schema for LinkExternalIssue model

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/model/item/LinkExternalIssueRQ.java
+++ b/src/main/java/com/epam/ta/reportportal/model/item/LinkExternalIssueRQ.java
@@ -38,7 +38,6 @@ public class LinkExternalIssueRQ extends ExternalIssueRQ {
   @Valid
   @Size(max = 300)
   @JsonProperty(value = "issues")
-  @Schema(implementation = Issue.ExternalSystemIssue.class)
   private List<Issue.ExternalSystemIssue> issues;
 
   public void setIssues(List<Issue.ExternalSystemIssue> values) {


### PR DESCRIPTION
This PR removes the incorrect `@Schema` annotation from the `LinkExternalIssueRQ` model, where a field was mistakenly defined as a class instead of an array. 
SpringDoc automatically infers `List<T> `fields as arrays in the OpenAPI schema, so the annotation was redundant. 

This addresses [GitHub Issue #2514](https://github.com/reportportal/reportportal/issues/2514).