### PR TITLE
External consumer for user creation events

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/events/MessageBusImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/events/MessageBusImpl.java
@@ -55,8 +55,7 @@ public class MessageBusImpl implements MessageBus {
   }
 
   private String generateKey(Activity activity) {
-    return String.format("activity.%d.%s.%s",
-        activity.getProjectId(),
+    return String.format("activity.%s.%s",
         activity.getObjectType(),
         activity.getEventName());
   }

--- a/src/main/java/com/epam/ta/reportportal/core/organization/PersonalOrganizationService.java
+++ b/src/main/java/com/epam/ta/reportportal/core/organization/PersonalOrganizationService.java
@@ -18,7 +18,7 @@ package com.epam.ta.reportportal.core.organization;
 
 import com.epam.reportportal.api.model.OrganizationInfo;
 import com.epam.ta.reportportal.core.plugin.Pf4jPluginBox;
-import com.epam.ta.reportportal.entity.user.User;
+import com.epam.ta.reportportal.dao.UserRepository;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,30 +33,35 @@ import org.springframework.stereotype.Service;
 public class PersonalOrganizationService {
 
   private final Pf4jPluginBox pluginBox;
+  private final UserRepository userRepository;
 
   /**
    * Constructor for PersonalOrganizationService.
    *
    * @param pluginBox The plugin box to retrieve organization extensions.
    */
-  public PersonalOrganizationService(Pf4jPluginBox pluginBox) {
+  public PersonalOrganizationService(Pf4jPluginBox pluginBox, UserRepository userRepository) {
     this.pluginBox = pluginBox;
+    this.userRepository = userRepository;
   }
 
   /**
    * Creates a personal organization for the given user.
    *
-   * @param user The user for whom the personal organization is to be created.
+   * @param userId The ID of the user for whom to create the personal organization.
    * @return An Optional containing the OrganizationInfo if creation was successful, or empty if it failed.
    */
-  public Optional<OrganizationInfo> create(User user) {
+  public Optional<OrganizationInfo> createPersonalOrganization(long userId) {
     try {
+      var user = userRepository.findById(userId)
+          .orElseThrow(() -> new IllegalStateException("User with id " + userId + " not found"));
+
       return getOrgExtension().map(ext -> ext.createPersonalOrganization(user));
     } catch (IllegalStateException e) {
       log.warn("Can't create personal organization, reason: {}", e.getMessage());
       return Optional.empty();
     } catch (Exception e) {
-      log.error("Can't create personal organization for user: {}", user.getLogin(), e);
+      log.error("Can't create personal organization for user: {}", userId, e);
       return Optional.empty();
     }
   }

--- a/src/main/java/com/epam/ta/reportportal/core/user/impl/CreateUserHandlerImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/user/impl/CreateUserHandlerImpl.java
@@ -85,7 +85,7 @@ public class CreateUserHandlerImpl implements CreateUserHandler {
 
     var savedUser = saveUser(request);
 
-    personalOrganizationService.create(savedUser);
+    personalOrganizationService.createPersonalOrganization(savedUser.getId());
 
     var userCreatedEvent = new UserCreatedEvent(
         TO_ACTIVITY_RESOURCE.apply(savedUser, null),

--- a/src/main/java/com/epam/ta/reportportal/core/user/impl/UserInvitationHandler.java
+++ b/src/main/java/com/epam/ta/reportportal/core/user/impl/UserInvitationHandler.java
@@ -168,7 +168,7 @@ public class UserInvitationHandler {
     var createdUser = saveUser(invitationActivation, bid);
     assignOrganizationsAndProjects(createdUser, bid.getMetadata());
     userCreationBidRepository.deleteByUuid(bid.getUuid());
-    personalOrganizationService.create(createdUser);
+    personalOrganizationService.createPersonalOrganization(createdUser.getId());
 
     var userCreatedEvent = new UserCreatedEvent(
         TO_ACTIVITY_RESOURCE.apply(createdUser, null),

--- a/src/main/java/com/epam/ta/reportportal/job/FlushingDataJob.java
+++ b/src/main/java/com/epam/ta/reportportal/job/FlushingDataJob.java
@@ -154,7 +154,7 @@ public class FlushingDataJob implements Job {
         .addPassword(passwordEncoder.encode(request.getPassword())).get();
     projectRepository.save(personalProjectService.generatePersonalProject(user));
     var savedUser = userRepository.save(user);
-    personalOrganizationService.create(savedUser);
+    personalOrganizationService.createPersonalOrganization(savedUser.getId());
     LOGGER.info("Default user has been successfully created.");
   }
 

--- a/src/main/java/com/epam/ta/reportportal/ws/rabbit/UserCreatedConsumer.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/rabbit/UserCreatedConsumer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.ta.reportportal.ws.rabbit;
+
+import com.epam.ta.reportportal.core.organization.PersonalOrganizationService;
+import com.epam.ta.reportportal.entity.activity.Activity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.ExchangeTypes;
+import org.springframework.amqp.rabbit.annotation.Exchange;
+import org.springframework.amqp.rabbit.annotation.Queue;
+import org.springframework.amqp.rabbit.annotation.QueueBinding;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumer for user created messages.
+ *
+ * @author <a href="mailto:reingold_shekhtel@epam.com">Shekhtel Reingold</a>
+ */
+@Slf4j
+@Component
+public class UserCreatedConsumer {
+
+  private final PersonalOrganizationService personalOrganizationService;
+
+  /**
+   * Constructor for UserCreatedConsumer.
+   *
+   * @param personalOrganizationService The service to handle personal organization creation.
+   */
+  public UserCreatedConsumer(PersonalOrganizationService personalOrganizationService) {
+    this.personalOrganizationService = personalOrganizationService;
+  }
+
+  /**
+   * Handles the incoming Activity message for user creation.
+   *
+   * @param activity The activity payload containing user information.
+   */
+  @RabbitListener(
+      bindings = @QueueBinding(
+          value = @Queue(value = "${rp.user.created.external.queue:user.created}", durable = "true", autoDelete = "false"),
+          exchange = @Exchange(value = "${rp.activity.exchange:activity}", type = ExchangeTypes.TOPIC),
+          key = "${rp.user.created.external.routing:activity.USER.createUser.external}"
+      ),
+      containerFactory = "rabbitListenerContainerFactory"
+  )
+  public void onEvent(@Payload Activity activity) {
+    if (activity != null && activity.getObjectId() != null) {
+      personalOrganizationService.createPersonalOrganization(activity.getObjectId());
+    }
+  }
+}

--- a/src/test/java/com/epam/ta/reportportal/core/events/MessageBusImplTest.java
+++ b/src/test/java/com/epam/ta/reportportal/core/events/MessageBusImplTest.java
@@ -50,7 +50,7 @@ public class MessageBusImplTest {
     lenient().when(activity.getObjectType()).thenReturn(EVENT_OBJECT);
     lenient().when(activity.getEventName()).thenReturn(EVENT_NAME);
 
-    activityKey = String.format("activity.%d.%s.%s", PROJECT_ID, EVENT_OBJECT, EVENT_NAME);
+    activityKey = String.format("activity.%s.%s", EVENT_OBJECT, EVENT_NAME);
   }
 
   @Test

--- a/src/test/java/com/epam/ta/reportportal/core/organization/PersonalOrganizationServiceTest.java
+++ b/src/test/java/com/epam/ta/reportportal/core/organization/PersonalOrganizationServiceTest.java
@@ -17,10 +17,12 @@
 package com.epam.ta.reportportal.core.organization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.epam.reportportal.api.model.OrganizationInfo;
 import com.epam.ta.reportportal.core.plugin.Pf4jPluginBox;
+import com.epam.ta.reportportal.dao.UserRepository;
 import com.epam.ta.reportportal.entity.user.User;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -38,15 +40,17 @@ public class PersonalOrganizationServiceTest {
   @Mock
   private Pf4jPluginBox pluginBox;
 
+  @Mock
+  private UserRepository userRepository;
+
   @InjectMocks
   private PersonalOrganizationService personalOrganizationService;
-
-  private final User user = new User();
 
   @Test
   public void pluginNotFound() {
     when(pluginBox.getInstance(OrganizationExtensionPoint.class)).thenReturn(Optional.empty());
-    Optional<OrganizationInfo> result = personalOrganizationService.create(user);
+    when(userRepository.findById(0L)).thenReturn(Optional.of(new User()));
+    Optional<OrganizationInfo> result = personalOrganizationService.createPersonalOrganization(0L);
 
     assertEquals(Optional.empty(), result);
   }
@@ -54,7 +58,8 @@ public class PersonalOrganizationServiceTest {
   @Test
   public void pluginThrowsException() {
     when(pluginBox.getInstance(OrganizationExtensionPoint.class)).thenThrow(new RuntimeException("Test exception"));
-    Optional<OrganizationInfo> result = personalOrganizationService.create(user);
+    when(userRepository.findById(0L)).thenReturn(Optional.of(new User()));
+    Optional<OrganizationInfo> result = personalOrganizationService.createPersonalOrganization(0L);
 
     assertEquals(Optional.empty(), result);
   }

--- a/src/test/java/com/epam/ta/reportportal/core/organization/PersonalOrganizationServiceTest.java
+++ b/src/test/java/com/epam/ta/reportportal/core/organization/PersonalOrganizationServiceTest.java
@@ -17,7 +17,6 @@
 package com.epam.ta.reportportal.core.organization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.epam.reportportal.api.model.OrganizationInfo;


### PR DESCRIPTION
This pull request refactors the way personal organizations are created for users, shifting from passing user objects to passing user IDs and retrieving users via the repository. It also introduces a new RabbitMQ consumer for handling user creation events and updates related tests and key generation logic to align with these changes.

### Refactoring and Service Improvements

* Refactored `PersonalOrganizationService` to accept a `userId` instead of a `User` object, retrieving the user internally via `UserRepository`. The method is now named `createPersonalOrganization` and all usages have been updated accordingly. [[1]](diffhunk://#diff-bc3b17640978d2595b013c2ae2f2c4aa5ecc8ea5ffeec9a3084cf5a688571fd7L21-R21) [[2]](diffhunk://#diff-bc3b17640978d2595b013c2ae2f2c4aa5ecc8ea5ffeec9a3084cf5a688571fd7R36-R64) [[3]](diffhunk://#diff-cd964650d7826742a7a6006165dbd8cd8d13510768863d515ccae748767db247L88-R88) [[4]](diffhunk://#diff-c20f71afc232c2b946cd9158e4e9e10de775d90b4061bc8ddd8509d8d6e34479L171-R171) [[5]](diffhunk://#diff-411b6fbe679856c0e5bc1d4bb52ab63be1d1a219336a74cbbf2f3692c85403d4L157-R157)
* Updated unit tests for `PersonalOrganizationService` to mock `UserRepository` and test the new method signature. [[1]](diffhunk://#diff-658fd37b2334cbf7a9a9390b86b0521f48f01ec6ce6b5bd2d0e22c264582f2a1R24) [[2]](diffhunk://#diff-658fd37b2334cbf7a9a9390b86b0521f48f01ec6ce6b5bd2d0e22c264582f2a1R42-R61)

### Event Handling

* Added a new `UserCreatedConsumer` class that listens for user creation events via RabbitMQ and triggers personal organization creation using the new service method.

### Key Generation Logic

* Simplified the activity key generation in `MessageBusImpl` by removing the project ID from the key format, and updated corresponding tests. [[1]](diffhunk://#diff-16f6539020444097fd377c02210a443881f70a160792e10a1c18e0b40d0b47c2L58-R58) [[2]](diffhunk://#diff-012df0c3f19a13e51385a59b9f8c88797230b5e72453c07fddb9074e716efc90L53-R53)