### PR TITLE
EPMRPP-105624 || Upgrade commons-dao + add getter to ProjectDeletedEvent

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Development versions
 commons-dev = "dc7c69b"
-commons-dao-dev = "ae1f509"
+commons-dao-dev = "3f725a9"
 plugin-api-dev = "e1786c4"
 
 # Platform versions

--- a/src/main/java/com/epam/ta/reportportal/core/events/MessageBusImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/events/MessageBusImpl.java
@@ -42,7 +42,7 @@ public class MessageBusImpl implements MessageBus {
 
   /**
    * Publishes activity to the queue with the following routing key
-   * <pre>{@code activity.<project-id>.<entity-type>.<action>}</pre>
+   * <pre>{@code activity.<entity-type>.<action>}</pre>
    *
    * @param event Activity event to be converted to Activity object
    */

--- a/src/main/java/com/epam/ta/reportportal/core/events/activity/ProjectDeletedEvent.java
+++ b/src/main/java/com/epam/ta/reportportal/core/events/activity/ProjectDeletedEvent.java
@@ -25,12 +25,14 @@ import com.epam.ta.reportportal.entity.activity.EventObject;
 import com.epam.ta.reportportal.entity.activity.EventPriority;
 import com.epam.ta.reportportal.entity.activity.EventSubject;
 import java.util.Objects;
+import lombok.Getter;
 
 /**
  * Event publish when project is deleted.
  *
  * @author Ryhor_Kukharenka
  */
+@Getter
 public class ProjectDeletedEvent extends AbstractEvent implements ActivityEvent {
 
   private final Long projectId;


### PR DESCRIPTION
Depends on https://github.com/reportportal/commons-dao/pull/1151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified activity event routing key format to activity.<entity-type>.<action> in the docs.

* **Refactor**
  * Added read-only access to project deletion details (project ID, name, organization ID) in emitted events for improved integration.

* **Chores**
  * Updated an internal development dependency version to keep the build up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->