### PR TITLE
EPMRPP-106883 || add role change validation for managers and update tests

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/core/organization/impl/OrganizationUsersHandlerImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/organization/impl/OrganizationUsersHandlerImpl.java
@@ -304,7 +304,7 @@ public class OrganizationUsersHandlerImpl implements OrganizationUsersHandler {
 
   private void assignToOrganization(OrgUserUpdateRequest orgUserUpdateRequest,
       Optional<OrganizationUser> userOrganization, Organization organization, User assignedUser) {
-    validateManagerChangingRole(orgUserUpdateRequest.getOrgRole(), organization.getId(), assignedUser);
+    validateManagerChangingRole(orgUserUpdateRequest.getOrgRole(), assignedUser, userOrganization);
 
     OrganizationUser organizationUser = userOrganization.orElse(new OrganizationUser());
     if (organizationUser.getOrganization() == null) {
@@ -316,14 +316,15 @@ public class OrganizationUsersHandlerImpl implements OrganizationUsersHandler {
     organizationUserRepository.save(organizationUser);
   }
 
-  private void validateManagerChangingRole(OrgRole newOrgRole, Long orgId, User assignedUser) {
+  private void validateManagerChangingRole(OrgRole newOrgRole, User assignedUser,
+      Optional<OrganizationUser> userOrganization) {
     var rpUser = SecurityContextUtils.getPrincipal();
-    var currentOrgRole = organizationUserRepository.findByUserIdAndOrganization_Id(rpUser.getUserId(), orgId);
 
+    // Only check if the current user is trying to change their own role
     if (Objects.equals(rpUser.getUserId(), assignedUser.getId())
         && !rpUser.getUserRole().equals(UserRole.ADMINISTRATOR)
-        && currentOrgRole.isPresent()
-        && currentOrgRole.get().getOrganizationRole().equals(OrganizationRole.MANAGER)
+        && userOrganization.isPresent()
+        && userOrganization.get().getOrganizationRole().equals(OrganizationRole.MANAGER)
         && !newOrgRole.equals(MANAGER)
     ) {
       throw new ReportPortalException(ErrorType.ACCESS_DENIED, "Impossible to change the role of the own account");

--- a/src/main/java/com/epam/ta/reportportal/core/organization/impl/OrganizationUsersHandlerImpl.java
+++ b/src/main/java/com/epam/ta/reportportal/core/organization/impl/OrganizationUsersHandlerImpl.java
@@ -33,6 +33,7 @@ import static com.epam.ta.reportportal.ws.converter.converters.OrganizationConve
 import static com.epam.ta.reportportal.ws.converter.converters.OrganizationUserConverter.MEMBERSHIP_TO_ORG_USER_PROJECT;
 import static java.util.function.Predicate.isEqual;
 
+import com.epam.reportportal.api.model.OrgRole;
 import com.epam.reportportal.api.model.OrgUserAssignment;
 import com.epam.reportportal.api.model.OrgUserProjectPage;
 import com.epam.reportportal.api.model.OrgUserUpdateRequest;
@@ -59,8 +60,11 @@ import com.epam.ta.reportportal.entity.project.Project;
 import com.epam.ta.reportportal.entity.user.OrganizationUser;
 import com.epam.ta.reportportal.entity.user.ProjectUser;
 import com.epam.ta.reportportal.entity.user.User;
+import com.epam.ta.reportportal.entity.user.UserRole;
+import com.epam.ta.reportportal.util.SecurityContextUtils;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -300,6 +304,8 @@ public class OrganizationUsersHandlerImpl implements OrganizationUsersHandler {
 
   private void assignToOrganization(OrgUserUpdateRequest orgUserUpdateRequest,
       Optional<OrganizationUser> userOrganization, Organization organization, User assignedUser) {
+    validateManagerChangingRole(orgUserUpdateRequest.getOrgRole(), organization.getId(), assignedUser);
+
     OrganizationUser organizationUser = userOrganization.orElse(new OrganizationUser());
     if (organizationUser.getOrganization() == null) {
       organizationUser.setOrganization(organization);
@@ -309,4 +315,19 @@ public class OrganizationUsersHandlerImpl implements OrganizationUsersHandler {
         orgUserUpdateRequest.getOrgRole().getValue()));
     organizationUserRepository.save(organizationUser);
   }
+
+  private void validateManagerChangingRole(OrgRole newOrgRole, Long orgId, User assignedUser) {
+    var rpUser = SecurityContextUtils.getPrincipal();
+    var currentOrgRole = organizationUserRepository.findByUserIdAndOrganization_Id(rpUser.getUserId(), orgId);
+
+    if (Objects.equals(rpUser.getUserId(), assignedUser.getId())
+        && !rpUser.getUserRole().equals(UserRole.ADMINISTRATOR)
+        && currentOrgRole.isPresent()
+        && currentOrgRole.get().getOrganizationRole().equals(OrganizationRole.MANAGER)
+        && !newOrgRole.equals(MANAGER)
+    ) {
+      throw new ReportPortalException(ErrorType.ACCESS_DENIED, "Impossible to change the role of the own account");
+    }
+  }
 }
+

--- a/src/test/java/com/epam/ta/reportportal/ws/controller/OrganizationUsersControllerTest.java
+++ b/src/test/java/com/epam/ta/reportportal/ws/controller/OrganizationUsersControllerTest.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.epam.reportportal.api.model.OrgRole;
 import com.epam.reportportal.api.model.OrgUserAssignment;
+import com.epam.reportportal.api.model.OrgUserUpdateRequest;
 import com.epam.reportportal.api.model.ProjectRole;
 import com.epam.reportportal.api.model.UserAssignmentResponse;
 import com.epam.reportportal.api.model.UserProjectInfo;
@@ -269,7 +270,7 @@ class OrganizationUsersControllerTest extends BaseMvcTest {
 
   @Test
   @DisplayName("Admin, Manager sends request to assign user to organization with duplicate projects and different project roles")
-  void duplicatePorjectsWithDifferentRoles() throws Exception {
+  void duplicateProjectsWithDifferentRoles() throws Exception {
     Long userId = 108L;
     UserProjectInfo project1 = new UserProjectInfo()
         .projectRole(ProjectRole.VIEWER)
@@ -327,6 +328,45 @@ class OrganizationUsersControllerTest extends BaseMvcTest {
     performUnassignUserFailed(203L, 107L, adminToken, status().is4xxClientError());
   }
 
+  @Test
+  @DisplayName("Manager tries to change their own role from MANAGER to MEMBER - should fail with ACCESS_DENIED")
+  void managerChangesOwnRoleToMember() throws Exception {
+    Long orgId = ORG_ID_1; // Organization 201 where user 104 is a manager
+    Long userId = 104L; // Manager user ID from test data
+    
+    OrgUserUpdateRequest updateRequest = new OrgUserUpdateRequest()
+        .orgRole(OrgRole.MEMBER)
+        .projects(new ArrayList<>());
+    
+    performUpdateUserFailed(orgId, userId, updateRequest, managerToken, status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("Manager changes another user's role - should succeed")
+  void managerChangesOtherUserRole() throws Exception {
+    Long orgId = ORG_ID_1; // Organization 201 where user 104 is a manager
+    Long userId = 107L; // Different user ID (member in this org)
+    
+    OrgUserUpdateRequest updateRequest = new OrgUserUpdateRequest()
+        .orgRole(OrgRole.MEMBER)
+        .projects(new ArrayList<>());
+    
+    performUpdateUserSuccess(orgId, userId, updateRequest, managerToken);
+  }
+
+  @Test
+  @DisplayName("Admin changes manager's role - should succeed")
+  void adminChangesManagerRole() throws Exception {
+    Long orgId = ORG_ID_1; // Organization 201
+    Long userId = 104L; // Manager user ID
+    
+    OrgUserUpdateRequest updateRequest = new OrgUserUpdateRequest()
+        .orgRole(OrgRole.MEMBER)
+        .projects(new ArrayList<>());
+    
+    performUpdateUserSuccess(orgId, userId, updateRequest, adminToken);
+  }
+
 
   private UserAssignmentResponse performAssignUserSuccess(Long orgId, OrgUserAssignment rq,
       String token)
@@ -352,7 +392,8 @@ class OrganizationUsersControllerTest extends BaseMvcTest {
     assertTrue(organizationUserRepository.findByUserIdAndOrganization_Id(userId, orgId).isEmpty());
   }
 
-  private Object performUnassignUserFailed(Long orgId, Long userId, String token, ResultMatcher status) throws Exception {
+  private Object performUnassignUserFailed(Long orgId, Long userId, String token, ResultMatcher status)
+      throws Exception {
     var result = performUnassignUserRequest(WITH_USER_ID_URL.formatted(orgId, userId), token, status);
     return objectMapper.readValue(result, Object.class);
   }
@@ -392,6 +433,29 @@ class OrganizationUsersControllerTest extends BaseMvcTest {
       var projectUser = projectUserRepository.getById(projectUserId);
       Assertions.assertNotNull(projectUser);
     });
+  }
+
+  private void performUpdateUserSuccess(Long orgId, Long userId, OrgUserUpdateRequest request, String token)
+      throws Exception {
+    performUpdateUserRequest(WITH_USER_ID_URL.formatted(orgId, userId), request, token, status().isOk());
+  }
+
+  private void performUpdateUserFailed(Long orgId, Long userId, OrgUserUpdateRequest request, String token,
+      ResultMatcher status) throws Exception {
+    performUpdateUserRequest(WITH_USER_ID_URL.formatted(orgId, userId), request, token, status);
+  }
+
+  private String performUpdateUserRequest(String url, OrgUserUpdateRequest request, String token, ResultMatcher status)
+      throws Exception {
+    return mockMvc.perform(MockMvcRequestBuilders
+            .put(url)
+            .content(objectMapper.writeValueAsBytes(request))
+            .contentType(APPLICATION_JSON)
+            .with(token(token)))
+        .andExpect(status)
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened organization role update permissions: managers can no longer change their own role away from Manager; managers can still change other users’ roles where allowed; administrators retain full control. Users now receive clear access-denied feedback when attempting unauthorized changes, reducing risk of accidental loss of managerial privileges and organization lockout.

* **Tests**
  * Added coverage verifying manager/self-role restrictions, manager-updating-others, and admin role changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->