### PR TITLE
EPMRPP-108089 || Data stream endpoint

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/ws/controller/FileStorageController.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/controller/FileStorageController.java
@@ -217,8 +217,21 @@ public class FileStorageController {
 
     long rangeStart = range.getRangeStart(fileLength);
     long rangeEnd = Math.min(range.getRangeEnd(fileLength), fileLength - 1);
-    headers.setContentLength(rangeEnd - rangeStart + 1);
+
+    if (rangeStart >= fileLength || rangeStart > rangeEnd) {
+      try {
+        binaryStream.close();
+      } catch (IOException ignored) {
+      }
+
+      headers.set(HttpHeaders.CONTENT_RANGE, "bytes */" + fileLength);
+      return ResponseEntity.status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+          .headers(headers)
+          .build();
+    }
+
     headers.set(HttpHeaders.CONTENT_RANGE, "bytes " + rangeStart + "-" + rangeEnd + "/" + fileLength);
+    headers.setContentLength(rangeEnd - rangeStart + 1);
 
     StreamingResponseBody responseBody = outputStream -> {
       try (InputStream inputStream = binaryStream) {

--- a/src/test/java/com/epam/ta/reportportal/ws/controller/FileStorageControllerStreamingResponseTest.java
+++ b/src/test/java/com/epam/ta/reportportal/ws/controller/FileStorageControllerStreamingResponseTest.java
@@ -116,6 +116,27 @@ class FileStorageControllerStreamingResponseTest {
     assertArrayEquals(expected, output.toByteArray());
   }
 
+  @Test
+  void returnsRequestedRangeNotSatisfiableWhenRangeExceedsLength() {
+    var data = new byte[100];
+    var binaryData = mock(BinaryData.class);
+    when(binaryData.getInputStream()).thenReturn(new ByteArrayInputStream(data));
+    when(binaryData.getContentType()).thenReturn(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+    when(binaryData.getFileName()).thenReturn("data.bin");
+    when(binaryData.getLength()).thenReturn((long) data.length);
+    when(request.getHeader(HttpHeaders.RANGE)).thenReturn("bytes=1000-");
+
+    var response = invokeToStreamingResponse(binaryData);
+
+    assertEquals(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_OCTET_STREAM, response.getHeaders().getContentType());
+    assertEquals("inline", response.getHeaders().getContentDisposition().getType());
+    assertEquals("data.bin", response.getHeaders().getContentDisposition().getFilename());
+    assertEquals("bytes", response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES));
+    assertEquals("bytes */100", response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE));
+    assertNull(response.getBody());
+  }
+
   private ResponseEntity<StreamingResponseBody> invokeToStreamingResponse(BinaryData binaryData) {
     return ReflectionTestUtils.invokeMethod(fileStorageController, "toStreamingResponse", binaryData, request);
   }


### PR DESCRIPTION
This pull request enhances the file streaming capabilities of the `FileStorageController` by introducing a new endpoint for streaming file downloads with HTTP range support, improving response handling, and adding comprehensive tests for these features. The changes modernize the controller, improve API usability, and ensure robust handling of partial content requests.

**File streaming improvements:**

* Added a new endpoint `/{projectKey}/streams/{dataId}` to `FileStorageController` that streams file content using `StreamingResponseBody`, supporting HTTP range requests for partial content delivery. This enables more efficient and resumable downloads.
* Implemented the `toStreamingResponse` method, which builds a `ResponseEntity<StreamingResponseBody>` with proper headers (including `Content-Type`, `Content-Disposition`, `Content-Range`, and `Accept-Ranges`) and supports both full and partial content responses based on the presence of the `Range` header.

**Code cleanup and refactoring:**

* Removed the unused `EditUserHandler` dependency from the controller's constructor and internal fields, simplifying the class.
* Improved method and class documentation for better clarity and maintainability.

**Testing:**

* Added a dedicated test class `FileStorageControllerStreamingResponseTest` with unit tests covering scenarios for missing streams, full content delivery, and partial content delivery based on range headers. This ensures the new streaming logic works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streaming file-download endpoint for large files, including HTTP Range support for partial downloads.
  * Responses include correct headers (Content-Type, Content-Disposition, Accept-Ranges) and preserve filenames.

* **Refactor**
  * Simplified controller wiring and standardized routing (controller now under /v1/data); non-streaming downloads remain unchanged.
  * Retained admin CSV-based cleanup for attachments.

* **Tests**
  * Added tests for streaming behavior: no-content, full downloads, and ranged partial downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->