### PR TITLE
Add cache-control for getUsersUserIdAvatar

### DIFF
--- a/src/main/java/com/epam/reportportal/base/ws/controller/GeneratedUserController.java
+++ b/src/main/java/com/epam/reportportal/base/ws/controller/GeneratedUserController.java
@@ -54,12 +54,14 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -161,6 +163,7 @@ public class GeneratedUserController extends BaseController implements UsersApi 
     Resource resource = new InputStreamResource(binaryData.getInputStream());
 
     return ResponseEntity.ok()
+        .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS))
         .contentType(MediaType.parseMediaType(binaryData.getContentType()))
         .header(CONTENT_DISPOSITION,
             "attachment; filename=\"" + binaryData.getFileName() + "\"")


### PR DESCRIPTION
- **HTTP caching enhancement:**
  * In `GeneratedUserController.java`, added a `Cache-Control: max-age=3600` header to avatar responses by using `CacheControl.maxAge(1, TimeUnit.HOURS)` in the `getUsersUserIdAvatar` method.

- **Dependency update:**
  * Imported `CacheControl` and `TimeUnit` to support the new caching functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caching behavior for user avatar images. The avatar endpoint now sets appropriate cache headers, allowing client applications to cache avatar images for up to one hour, reducing server load and improving response times for repeated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->