### PR TITLE
EPMRPP-113893 || enhance access control for project role changes

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/project/patch/ProjectUserAssignmentHelper.java
+++ b/src/main/java/com/epam/reportportal/base/core/project/patch/ProjectUserAssignmentHelper.java
@@ -104,8 +104,15 @@ public class ProjectUserAssignmentHelper {
       return;
     }
 
-    expect(user.getId(), not(isEqual(principal.getUserId())))
-        .verify(ErrorType.ACCESS_DENIED, "Self project role change is not allowed");
+    var principalIsOrgManager = organizationUserRepository
+        .findByUserIdAndOrganization_Id(principal.getUserId(), org.getId())
+        .map(ou -> OrganizationRole.MANAGER.equals(ou.getOrganizationRole()))
+        .orElse(false);
+
+    if (!principalIsOrgManager) {
+      expect(user.getId(), not(isEqual(principal.getUserId())))
+          .verify(ErrorType.ACCESS_DENIED, "Self project role change is not allowed");
+    }
 
     if (OrganizationType.EXTERNAL.equals(org.getOrganizationType()) && UserType.UPSA.equals(user.getUserType())) {
       throw new ReportPortalException(ErrorType.UNABLE_ASSIGN_UNASSIGN_USER_TO_PROJECT,

--- a/src/test/java/com/epam/reportportal/base/ws/controller/OrganizationProjectControllerTest.java
+++ b/src/test/java/com/epam/reportportal/base/ws/controller/OrganizationProjectControllerTest.java
@@ -484,7 +484,7 @@ class OrganizationProjectControllerTest extends BaseMvcTest {
   @Test
   void patchUserRoleHimself() throws Exception {
     var values = List.of(
-        new UserProjectInfo(104L, ProjectRole.EDITOR)
+        new UserProjectInfo(105L, ProjectRole.EDITOR)
     );
     PatchOperation patchOperation = new PatchOperation()
         .op(OperationType.REPLACE)
@@ -493,7 +493,7 @@ class OrganizationProjectControllerTest extends BaseMvcTest {
 
     mockMvc.perform(patch("/organizations/201/projects/301")
             .contentType(MediaType.APPLICATION_JSON)
-            .with(token(managerToken))
+            .with(token(editorToken))
             .content(objectMapper.writeValueAsString(Collections.singletonList(patchOperation))))
         .andExpect(status().isForbidden());
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization controls for project role self-assignment have been refined. Organization managers can now modify their own project role assignments within projects, whereas this capability was previously restricted to system administrators only. Related authorization test cases were updated to validate this behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->