### PR TITLE
EPMRPP-116092 || Allow upsa users update

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/user/UserMutationService.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/UserMutationService.java
@@ -18,21 +18,11 @@ package com.epam.reportportal.base.core.user;
 
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.entity.user.User;
-import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 
 /**
  * Service for mutating user entity attributes with validation and authorization checks.
  */
 public interface UserMutationService {
-
-  /**
-   * Validates that the user can be updated. Immutable user types (e.g. UPSA) are rejected.
-   * Call before any mutation when handling PUT or PATCH requests.
-   *
-   * @param user target user to validate
-   * @throws ReportPortalException with ACCESS_DENIED when user is immutable
-   */
-  void validateUserUpdatable(User user);
 
   /**
    * Updates user email with validation and duplicate checking.

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/EditUserHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/EditUserHandlerImpl.java
@@ -115,8 +115,6 @@ public class EditUserHandlerImpl implements EditUserHandler {
     User user = userRepository.findByLogin(username)
         .orElseThrow(() -> new ReportPortalException(ErrorType.USER_NOT_FOUND, username));
 
-    userMutationService.validateUserUpdatable(user);
-
     updateRestrictedFields(editor, user, editUserRq);
 
     ofNullable(editUserRq.getEmail())

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImpl.java
@@ -20,7 +20,6 @@ import static com.epam.reportportal.base.infrastructure.model.ValidationConstrai
 import static com.epam.reportportal.base.infrastructure.model.ValidationConstraints.MIN_USER_NAME_LENGTH;
 import static com.epam.reportportal.base.infrastructure.model.ValidationConstraints.USER_FULL_NAME_REGEXP;
 import static com.epam.reportportal.base.infrastructure.rules.commons.validation.BusinessRule.expect;
-import static com.epam.reportportal.base.infrastructure.rules.exception.ErrorType.ACCESS_DENIED;
 import static com.epam.reportportal.base.infrastructure.rules.exception.ErrorType.BAD_REQUEST_ERROR;
 import static com.epam.reportportal.base.infrastructure.rules.exception.ErrorType.USER_ALREADY_EXISTS;
 import static com.epam.reportportal.base.util.email.EmailRulesValidator.NORMALIZE_EMAIL;
@@ -57,13 +56,6 @@ public class UserMutationServiceImpl implements UserMutationService {
   private final UserRepository userRepository;
   private final ProjectRepository projectRepository;
   private final ApplicationEventPublisher eventPublisher;
-
-  @Override
-  public void validateUserUpdatable(User user) {
-    if (user.getUserType() == UserType.UPSA) {
-      throw new ReportPortalException(ACCESS_DENIED, "UPSA users cannot be updated.");
-    }
-  }
 
   @Override
   public void updateEmail(User user, String rawEmail, ReportPortalUser editor) {

--- a/src/main/java/com/epam/reportportal/base/core/user/patch/PatchUserHandler.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/patch/PatchUserHandler.java
@@ -40,10 +40,8 @@ import org.springframework.util.Assert;
  * <p>Authorization rules:
  * <ul>
  *   <li>Administrators may update email, full_name, role, active, account_type and external_id of
- *       any non-UPSA user.</li>
- *   <li>Regular users (any type except UPSA) may update only their own email and full name.</li>
- *   <li>UPSA users' mutable fields (email, full_name, role, active, account_type, external_id)
- *       cannot be changed by anyone, including administrators.</li>
+ *       any user.</li>
+ *   <li>Regular users may update only their own email and full name.</li>
  * </ul>
  *
  * @author <a href="mailto:siarhei_hrabko@epam.com">Siarhei Hrabko</a>
@@ -97,8 +95,7 @@ public class PatchUserHandler {
    *   <li>Regular users are restricted to updating only their email and full name</li>
    * </ul>
    *
-   * <p>Additionally delegates to {@link UserMutationService#validateUserUpdatable(User)}
-   * for user-type-specific restrictions (e.g., UPSA users).
+   * <p>Additionally enforces field-level restrictions for non-administrators.
    *
    * @param user      the target user whose profile is being modified
    * @param operation the patch operation containing the field path and new value
@@ -108,8 +105,6 @@ public class PatchUserHandler {
   private void validateOperation(User user, PatchOperation operation) {
     String path = operation.getPath();
     Assert.isTrue(StringUtils.isNotEmpty(path), "The 'path' must not be null");
-
-    userMutationService.validateUserUpdatable(user);
 
     boolean isAdmin = SecurityContextUtils.isAdminRole();
     if (isAdmin) {

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/EditUserHandlerImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/EditUserHandlerImplTest.java
@@ -191,8 +191,8 @@ class EditUserHandlerImplTest {
         getRpUser("admin", UserRole.ADMINISTRATOR, OrganizationRole.MANAGER, ProjectRole.EDITOR, 1L)
     );
 
-    verify(userMutationService).updateEmail(user, "new@example.com", any());
-    verify(userMutationService).updateFullName(user, "New Name", any());
+    verify(userMutationService).updateEmail(eq(user), eq("new@example.com"), any());
+    verify(userMutationService).updateFullName(eq(user), eq("New Name"), any());
     verify(userRepository).save(user);
   }
 
@@ -211,8 +211,8 @@ class EditUserHandlerImplTest {
         getRpUser("test", UserRole.USER, OrganizationRole.MANAGER, ProjectRole.EDITOR, 1L)
     );
 
-    verify(userMutationService).updateEmail(user, "new@example.com", any());
-    verify(userMutationService).updateFullName(user, "New Name", any());
+    verify(userMutationService).updateEmail(eq(user), eq("new@example.com"), any());
+    verify(userMutationService).updateFullName(eq(user), eq("New Name"), any());
     verify(userRepository).save(user);
   }
 

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/EditUserHandlerImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/EditUserHandlerImplTest.java
@@ -21,9 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -179,33 +177,43 @@ class EditUserHandlerImplTest {
   }
 
   @Test
-  void editUpsaUserShouldFail() {
+  void editUpsaUserByAdminShouldSucceed() {
     User user = new User();
     user.setLogin("test");
     user.setUserType(UserType.UPSA);
     when(userRepository.findByLogin("test")).thenReturn(Optional.of(user));
-    doAnswer(invocation -> {
-      User u = invocation.getArgument(0);
-      if (u != null && u.getUserType() == UserType.UPSA) {
-        throw new ReportPortalException(ErrorType.ACCESS_DENIED, "UPSA users cannot be updated.");
-      }
-      return null;
-    }).when(userMutationService).validateUserUpdatable(any());
 
     final EditUserRQ editUserRQ = new EditUserRQ();
     editUserRQ.setEmail("new@example.com");
     editUserRQ.setFullName("New Name");
 
-    final ReportPortalException exception = assertThrows(ReportPortalException.class,
-        () -> handler.editUser("test", editUserRQ,
-            getRpUser("admin", UserRole.ADMINISTRATOR, OrganizationRole.MANAGER, ProjectRole.EDITOR, 1L)
-        )
+    handler.editUser("test", editUserRQ,
+        getRpUser("admin", UserRole.ADMINISTRATOR, OrganizationRole.MANAGER, ProjectRole.EDITOR, 1L)
     );
 
-    assertEquals("You do not have enough permissions. UPSA users cannot be updated.",
-        exception.getMessage());
-    verify(userMutationService, never()).updateEmail(any(), any(), any());
-    verify(userMutationService, never()).updateFullName(any(), any(), any());
+    verify(userMutationService).updateEmail(user, "new@example.com", any());
+    verify(userMutationService).updateFullName(user, "New Name", any());
+    verify(userRepository).save(user);
+  }
+
+  @Test
+  void editUpsaUserByOwnerShouldSucceed() {
+    User user = new User();
+    user.setLogin("test");
+    user.setUserType(UserType.UPSA);
+    when(userRepository.findByLogin("test")).thenReturn(Optional.of(user));
+
+    final EditUserRQ editUserRQ = new EditUserRQ();
+    editUserRQ.setEmail("new@example.com");
+    editUserRQ.setFullName("New Name");
+
+    handler.editUser("test", editUserRQ,
+        getRpUser("test", UserRole.USER, OrganizationRole.MANAGER, ProjectRole.EDITOR, 1L)
+    );
+
+    verify(userMutationService).updateEmail(user, "new@example.com", any());
+    verify(userMutationService).updateFullName(user, "New Name", any());
+    verify(userRepository).save(user);
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/core/user/patch/PatchUserHandlerTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/patch/PatchUserHandlerTest.java
@@ -5,10 +5,9 @@ import static com.epam.reportportal.api.model.OperationType.REMOVE;
 import static com.epam.reportportal.api.model.OperationType.REPLACE;
 import static com.epam.reportportal.base.ReportPortalUserUtil.getRpUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,8 +38,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class PatchUserHandlerTest {
-
-  private static final String UPSA_IMMUTABLE_MESSAGE = "UPSA users cannot be updated.";
 
   @Mock
   private UserService userService;
@@ -205,120 +202,113 @@ class PatchUserHandlerTest {
   // --- Test Cases for UPSA Users ---
 
   @Test
-  @DisplayName("Profile owner (UPSA) updates own email - Should fail with ACCESS_DENIED")
-  void profileOwnerUpsaUpdatesOwnEmailShouldFail() {
+  @DisplayName("Profile owner (UPSA) updates own email - Should delegate to UserMutationService")
+  void profileOwnerUpsaUpdatesOwnEmailShouldSucceed() {
     targetUser.setId(principalUser.getUserId());
     targetUser.setUserType(UserType.UPSA);
     mockPrincipal(principalUser, false);
     when(userService.findById(targetUser.getId())).thenReturn(targetUser);
-    doThrow(new ReportPortalException(ErrorType.ACCESS_DENIED, UPSA_IMMUTABLE_MESSAGE))
-        .when(userMutationService).validateUserUpdatable(targetUser);
 
     PatchOperation op = new PatchOperation();
     op.setOp(REPLACE);
     op.setPath("/email");
     op.setValue("upsa_new@example.com");
-    ReportPortalException exception = assertThrows(ReportPortalException.class,
-        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+    patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op));
 
-    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
-    assertTrue(exception.getMessage().contains(UPSA_IMMUTABLE_MESSAGE));
+    verify(userMutationService).updateEmail(targetUser, "upsa_new@example.com", principalUser);
   }
 
   @Test
-  @DisplayName("Admin updates UPSA user's email - Should fail with ACCESS_DENIED")
-  void adminUpdatesUpsaUserEmailShouldFail() {
+  @DisplayName("Admin updates UPSA user's email - Should delegate to UserMutationService")
+  void adminUpdatesUpsaUserEmailShouldSucceed() {
     targetUser.setUserType(UserType.UPSA);
     mockPrincipal(principalUser, true);
     when(userService.findById(targetUser.getId())).thenReturn(targetUser);
-    doThrow(new ReportPortalException(ErrorType.ACCESS_DENIED, UPSA_IMMUTABLE_MESSAGE))
-        .when(userMutationService).validateUserUpdatable(targetUser);
 
     PatchOperation op = new PatchOperation();
     op.setOp(REPLACE);
     op.setPath("/email");
     op.setValue("admin_upsa_new@example.com");
-    ReportPortalException exception = assertThrows(ReportPortalException.class,
-        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+    patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op));
 
-    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
-    assertTrue(exception.getMessage().contains(UPSA_IMMUTABLE_MESSAGE));
+    verify(userMutationService).updateEmail(targetUser, "admin_upsa_new@example.com", principalUser);
   }
 
   @Test
-  @DisplayName("Admin updates UPSA user's external_id (REPLACE) - Should fail with ACCESS_DENIED")
-  void adminUpdatesUpsaUserExternalIdReplaceShouldFail() {
+  @DisplayName("Admin updates UPSA user's role - Should delegate to UserMutationService")
+  void adminUpdatesUpsaUserRoleShouldSucceed() {
     targetUser.setUserType(UserType.UPSA);
     mockPrincipal(principalUser, true);
     when(userService.findById(targetUser.getId())).thenReturn(targetUser);
-    doThrow(new ReportPortalException(ErrorType.ACCESS_DENIED, UPSA_IMMUTABLE_MESSAGE))
-        .when(userMutationService).validateUserUpdatable(targetUser);
+
+    PatchOperation op = new PatchOperation();
+    op.setOp(REPLACE);
+    op.setPath("/instance_role");
+    op.setValue(UserRole.ADMINISTRATOR.name());
+    patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op));
+
+    verify(userMutationService).updateInstanceRole(targetUser, UserRole.ADMINISTRATOR.name(), principalUser);
+  }
+
+  @Test
+  @DisplayName("Admin updates UPSA user's external_id (REPLACE) - Should delegate to UserMutationService")
+  void adminUpdatesUpsaUserExternalIdReplaceShouldSucceed() {
+    targetUser.setUserType(UserType.UPSA);
+    mockPrincipal(principalUser, true);
+    when(userService.findById(targetUser.getId())).thenReturn(targetUser);
 
     PatchOperation op = new PatchOperation();
     op.setOp(REPLACE);
     op.setPath("/external_id");
     op.setValue("new_external_id");
-    ReportPortalException exception = assertThrows(ReportPortalException.class,
-        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+    patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op));
 
-    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
-    assertTrue(exception.getMessage().contains(UPSA_IMMUTABLE_MESSAGE));
-    verify(userMutationService, never()).updateExternalId(any(), any());
+    verify(userMutationService).updateExternalId(targetUser, "new_external_id");
   }
 
   @Test
-  @DisplayName("Admin updates UPSA user's external_id (ADD) - Should fail with ACCESS_DENIED")
-  void adminUpdatesUpsaUserExternalIdAddShouldFail() {
+  @DisplayName("Admin updates UPSA user's external_id (ADD) - Should delegate to UserMutationService")
+  void adminUpdatesUpsaUserExternalIdAddShouldSucceed() {
     targetUser.setUserType(UserType.UPSA);
     targetUser.setExternalId(null);
     mockPrincipal(principalUser, true);
     when(userService.findById(targetUser.getId())).thenReturn(targetUser);
-    doThrow(new ReportPortalException(ErrorType.ACCESS_DENIED, UPSA_IMMUTABLE_MESSAGE))
-        .when(userMutationService).validateUserUpdatable(targetUser);
 
     PatchOperation op = new PatchOperation();
     op.setOp(ADD);
     op.setPath("/external_id");
     op.setValue("added_external_id");
-    ReportPortalException exception = assertThrows(ReportPortalException.class,
-        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+    patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op));
 
-    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
-    assertTrue(exception.getMessage().contains(UPSA_IMMUTABLE_MESSAGE));
-    verify(userMutationService, never()).updateExternalId(any(), any());
+    verify(userMutationService).updateExternalId(targetUser, "added_external_id");
   }
 
   @Test
-  @DisplayName("Admin updates UPSA user's external_id (REMOVE) - Should fail with ACCESS_DENIED")
-  void adminUpdatesUpsaUserExternalIdRemoveShouldFail() {
+  @DisplayName("Admin updates UPSA user's external_id (REMOVE) - Should clear external_id")
+  void adminUpdatesUpsaUserExternalIdRemoveShouldSucceed() {
     targetUser.setUserType(UserType.UPSA);
     targetUser.setExternalId("existing_external_id");
     mockPrincipal(principalUser, true);
     when(userService.findById(targetUser.getId())).thenReturn(targetUser);
-    doThrow(new ReportPortalException(ErrorType.ACCESS_DENIED, UPSA_IMMUTABLE_MESSAGE))
-        .when(userMutationService).validateUserUpdatable(targetUser);
 
     PatchOperation op = new PatchOperation();
     op.setOp(REMOVE);
     op.setPath("/external_id");
-    ReportPortalException exception = assertThrows(ReportPortalException.class,
-        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+    patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op));
 
-    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
-    assertTrue(exception.getMessage().contains(UPSA_IMMUTABLE_MESSAGE));
+    assertNull(targetUser.getExternalId());
+    verify(userMutationService, never()).updateExternalId(any(), any());
   }
 
   // --- Unified Error Messages ---
 
   @Test
-  @DisplayName("UPSA user updating own role fails with immutable user error")
-  void upsaUserUpdatesOwnRoleShouldFailWithImmutableError() {
+  @DisplayName("UPSA user updating own role fails with access denied for non-admin fields")
+  void upsaUserUpdatesOwnRoleShouldFailWithAccessDenied() {
     targetUser.setId(principalUser.getUserId());
     targetUser.setUserType(UserType.UPSA);
     mockPrincipal(principalUser, false);
     when(userService.findById(targetUser.getId())).thenReturn(targetUser);
-    doThrow(new ReportPortalException(ErrorType.ACCESS_DENIED, UPSA_IMMUTABLE_MESSAGE))
-        .when(userMutationService).validateUserUpdatable(targetUser);
 
     PatchOperation op = new PatchOperation();
     op.setOp(REPLACE);
@@ -328,7 +318,9 @@ class PatchUserHandlerTest {
         () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
 
     assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
-    assertTrue(exception.getMessage().contains(UPSA_IMMUTABLE_MESSAGE));
+    assertEquals(
+        "You do not have enough permissions. You can only update your own email and full name.",
+        exception.getMessage());
   }
 
   // --- Other Operations ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UPSA users can now be edited: admins may modify any UPSA profile; UPSA users may update their own email and full name.

* **Bug Fixes**
  * Authorization simplified to role-based checks, removing prior user-type update restrictions; related tests updated to reflect allowed UPSA edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->