### PR TITLE
EPMRPP-114388 || Add org/project deleted events on user delete

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/user/impl/CreateUserHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/CreateUserHandlerImpl.java
@@ -30,7 +30,6 @@ import static java.util.Optional.ofNullable;
 import com.epam.reportportal.api.model.InstanceUser;
 import com.epam.reportportal.api.model.NewUserRequest;
 import com.epam.reportportal.base.core.events.domain.UserCreatedEvent;
-import com.epam.reportportal.base.core.organization.PersonalOrganizationService;
 import com.epam.reportportal.base.core.user.CreateUserHandler;
 import com.epam.reportportal.base.core.user.UserMutationService;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
@@ -76,7 +75,6 @@ public class CreateUserHandlerImpl implements CreateUserHandler {
   private final ThreadPoolTaskExecutor emailExecutorService;
   private final PasswordEncoder passwordEncoder;
   private final ApplicationEventPublisher eventPublisher;
-  private final PersonalOrganizationService personalOrganizationService;
   private final UserMutationService userMutationService;
 
   @Override
@@ -86,8 +84,6 @@ public class CreateUserHandlerImpl implements CreateUserHandler {
     request.setEmail(email);
 
     var savedUser = saveUser(request);
-
-    personalOrganizationService.createPersonalOrganization(savedUser.getId());
 
     var userCreatedEvent = new UserCreatedEvent(
         TO_ACTIVITY_RESOURCE.apply(savedUser, null),

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImpl.java
@@ -18,6 +18,8 @@ package com.epam.reportportal.base.core.user.impl;
 
 import static com.epam.reportportal.base.ws.converter.converters.ExceptionConverter.TO_ERROR_RS;
 
+import com.epam.reportportal.base.core.events.domain.OrganizationDeletedEvent;
+import com.epam.reportportal.base.core.events.domain.ProjectDeletedEvent;
 import com.epam.reportportal.base.core.events.domain.UnassignUserEvent;
 import com.epam.reportportal.base.core.events.domain.UserDeletedEvent;
 import com.epam.reportportal.base.core.events.domain.UsersDeletedEvent;
@@ -28,8 +30,11 @@ import com.epam.reportportal.base.infrastructure.persistence.binary.UserBinaryDa
 import com.epam.reportportal.base.infrastructure.persistence.commons.Predicates;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectUserRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.UserRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.organization.OrganizationRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.organization.OrganizationUserRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.enums.OrganizationType;
 import com.epam.reportportal.base.infrastructure.persistence.entity.project.Project;
 import com.epam.reportportal.base.infrastructure.persistence.entity.user.User;
 import com.epam.reportportal.base.infrastructure.persistence.entity.user.UserRole;
@@ -76,6 +81,10 @@ public class DeleteUserHandlerImpl implements DeleteUserHandler {
 
   private final OrganizationUserRepository organizationUserRepository;
 
+  private final OrganizationRepository organizationRepository;
+
+  private final ProjectUserRepository projectUserRepository;
+
   private final Map<EmailTemplate, EmailNotificationStrategy> emailNotificationStrategyMapping;
 
   private final ApplicationEventPublisher applicationEventPublisher;
@@ -110,6 +119,10 @@ public class DeleteUserHandlerImpl implements DeleteUserHandler {
       projectRecipientHandler.handle(Lists.newArrayList(user), project);
       publishUserUnassignEvent(user, project.getId(), project.getOrganizationId());
     });
+
+    String actorLogin = loggedInUser.getUserId().equals(user.getId())
+        ? DELETED_USER : loggedInUser.getUsername();
+    publishPersonalOrganizationDeletedEvents(user, loggedInUser.getUserId(), actorLogin);
 
     dataStore.deleteUserPhoto(user);
     userRepository.delete(user);
@@ -190,5 +203,22 @@ public class DeleteUserHandlerImpl implements DeleteUserHandler {
     userActivityResource.setDefaultProjectId(projectId);
 
     applicationEventPublisher.publishEvent(new UnassignUserEvent(userActivityResource, orgId));
+  }
+
+  private void publishPersonalOrganizationDeletedEvents(User user, Long actorId, String actorLogin) {
+    organizationRepository.findByOwnerIdAndOrganizationType(user.getId(), OrganizationType.PERSONAL)
+        .ifPresent(org -> {
+          projectRepository.findAllByOrganizationId(org.getId())
+              .forEach(project -> {
+                List<Long> projectUserIds = projectUserRepository.findUserIdsByProjectId(project.getId());
+                applicationEventPublisher.publishEvent(
+                    new ProjectDeletedEvent(actorId, actorLogin, project.getId(), project.getName(), null,
+                        projectUserIds));
+              });
+
+          List<Long> orgUserIds = organizationUserRepository.findUserIdsByOrganizationId(org.getId());
+          applicationEventPublisher.publishEvent(
+              new OrganizationDeletedEvent(actorId, actorLogin, org.getId(), org.getName(), orgUserIds));
+        });
   }
 }

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/UserInvitationHandler.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/UserInvitationHandler.java
@@ -40,7 +40,6 @@ import com.epam.reportportal.base.core.events.domain.AssignUserEvent;
 import com.epam.reportportal.base.core.events.domain.UserCreatedEvent;
 import com.epam.reportportal.base.core.launch.util.LinkGenerator;
 import com.epam.reportportal.base.core.organization.OrganizationUserService;
-import com.epam.reportportal.base.core.organization.PersonalOrganizationService;
 import com.epam.reportportal.base.core.user.UserInvitationService;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectUserRepository;
@@ -93,7 +92,6 @@ public class UserInvitationHandler {
   private final ProjectRepository projectRepository;
   private final PasswordEncoder passwordEncoder;
   private final UserInvitationService userInvitationService;
-  private final PersonalOrganizationService personalOrganizationService;
   private final LinkGenerator linkGenerator;
 
   /**
@@ -149,7 +147,6 @@ public class UserInvitationHandler {
 
     assignOrganizationsAndProjects(createdUser, bid.getMetadata(), bid.getInvitingUser());
     userCreationBidRepository.deleteByUuid(bid.getUuid());
-    personalOrganizationService.createPersonalOrganization(createdUser.getId());
     userAuthenticator.authenticate(createdUser);
 
     return new Invitation()

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/organization/OrganizationRepository.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/organization/OrganizationRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.infrastructure.persistence.dao.organization;
+
+import com.epam.reportportal.base.infrastructure.persistence.dao.ReportPortalRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.enums.OrganizationType;
+import com.epam.reportportal.base.infrastructure.persistence.entity.organization.Organization;
+import java.util.Optional;
+
+/**
+ * Spring Data repository for {@link Organization} entities.
+ */
+public interface OrganizationRepository extends ReportPortalRepository<Organization, Long> {
+
+  Optional<Organization> findByOwnerIdAndOrganizationType(Long ownerId, OrganizationType organizationType);
+
+}

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImplTest.java
@@ -19,6 +19,8 @@ package com.epam.reportportal.base.core.user.impl;
 import static com.epam.reportportal.base.ReportPortalUserUtil.getRpUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.doNothing;
@@ -28,13 +30,20 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.epam.reportportal.base.core.events.domain.OrganizationDeletedEvent;
+import com.epam.reportportal.base.core.events.domain.ProjectDeletedEvent;
 import com.epam.reportportal.base.core.events.domain.UserDeletedEvent;
 import com.epam.reportportal.base.core.remover.ContentRemover;
 import com.epam.reportportal.base.infrastructure.persistence.binary.UserBinaryDataService;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectUserRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.UserRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.organization.OrganizationRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.organization.OrganizationUserRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.enums.OrganizationType;
+import com.epam.reportportal.base.infrastructure.persistence.entity.organization.Organization;
 import com.epam.reportportal.base.infrastructure.persistence.entity.organization.OrganizationRole;
+import com.epam.reportportal.base.infrastructure.persistence.entity.project.Project;
 import com.epam.reportportal.base.infrastructure.persistence.entity.project.ProjectRole;
 import com.epam.reportportal.base.infrastructure.persistence.entity.user.User;
 import com.epam.reportportal.base.infrastructure.persistence.entity.user.UserRole;
@@ -42,6 +51,7 @@ import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalExc
 import com.epam.reportportal.base.util.email.strategy.EmailNotificationStrategy;
 import com.epam.reportportal.base.util.email.strategy.EmailTemplate;
 import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -79,6 +89,12 @@ class DeleteUserHandlerImplTest {
   private OrganizationUserRepository organizationUserRepository;
 
   @Mock
+  private OrganizationRepository organizationRepository;
+
+  @Mock
+  private ProjectUserRepository projectUserRepository;
+
+  @Mock
   private ApplicationEventPublisher applicationEventPublisher;
 
   @InjectMocks
@@ -94,6 +110,8 @@ class DeleteUserHandlerImplTest {
     when(organizationUserRepository.findNonPersonalOrganizationIdsByUserId(user.getId())).thenReturn(
         Lists.newArrayList());
     when(projectRepository.findAllByUserLogin(user.getLogin())).thenReturn(Lists.newArrayList());
+    when(organizationRepository.findByOwnerIdAndOrganizationType(user.getId(), OrganizationType.PERSONAL))
+        .thenReturn(Optional.empty());
     doNothing().when(dataStore).deleteUserPhoto(any());
     when(emailNotificationStrategyMapping.get(any())).thenReturn(emailNotificationStrategy);
     doNothing().when(emailNotificationStrategy).sendEmail(any(), anyMap());
@@ -136,6 +154,49 @@ class DeleteUserHandlerImplTest {
 
     verify(repository, times(1)).findById(1L);
     verify(repository, times(0)).delete(any(User.class));
+  }
+
+  @Test
+  void deleteUserWithPersonalOrganizationShouldPublishOrgAndProjectEvents() {
+    User user = new User();
+    user.setId(2L);
+    user.setLogin("test");
+
+    Organization personalOrg = new Organization();
+    personalOrg.setId(10L);
+    personalOrg.setName("Personal Org");
+    personalOrg.setOwnerId(2L);
+    personalOrg.setOrganizationType(OrganizationType.PERSONAL);
+
+    Project project = new Project();
+    project.setId(100L);
+    project.setName("Personal Project");
+    project.setOrganizationId(10L);
+
+    doReturn(Optional.of(user)).when(repository).findById(2L);
+    when(organizationUserRepository.findNonPersonalOrganizationIdsByUserId(user.getId()))
+        .thenReturn(Lists.newArrayList());
+    when(projectRepository.findAllByUserLogin(user.getLogin())).thenReturn(Lists.newArrayList());
+    when(organizationRepository.findByOwnerIdAndOrganizationType(user.getId(), OrganizationType.PERSONAL))
+        .thenReturn(Optional.of(personalOrg));
+    when(organizationUserRepository.findUserIdsByOrganizationId(10L)).thenReturn(List.of(2L));
+    when(projectRepository.findAllByOrganizationId(10L)).thenReturn(List.of(project));
+    when(projectUserRepository.findUserIdsByProjectId(100L)).thenReturn(List.of(2L));
+    doNothing().when(dataStore).deleteUserPhoto(any());
+    when(emailNotificationStrategyMapping.get(any())).thenReturn(emailNotificationStrategy);
+    doNothing().when(emailNotificationStrategy).sendEmail(any(), anyMap());
+
+    handler.deleteUser(
+        2L, getRpUser("admin", UserRole.ADMINISTRATOR, OrganizationRole.MANAGER, ProjectRole.EDITOR,
+            1L));
+
+    verify(organizationRepository).findByOwnerIdAndOrganizationType(eq(2L), eq(OrganizationType.PERSONAL));
+    verify(applicationEventPublisher).publishEvent(argThat(event ->
+        event instanceof ProjectDeletedEvent projectEvent
+            && projectEvent.getOrganizationId() == null
+            && projectEvent.getProjectId().equals(100L)));
+    verify(applicationEventPublisher).publishEvent(isA(OrganizationDeletedEvent.class));
+    verify(applicationEventPublisher).publishEvent(isA(UserDeletedEvent.class));
   }
 
 }

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/UserInvitationHandlerEventTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/UserInvitationHandlerEventTest.java
@@ -30,7 +30,6 @@ import com.epam.reportportal.base.core.events.domain.AssignUserEvent;
 import com.epam.reportportal.base.core.events.domain.UserCreatedEvent;
 import com.epam.reportportal.base.core.launch.util.LinkGenerator;
 import com.epam.reportportal.base.core.organization.OrganizationUserService;
-import com.epam.reportportal.base.core.organization.PersonalOrganizationService;
 import com.epam.reportportal.base.core.user.UserInvitationService;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectUserRepository;
@@ -93,9 +92,6 @@ class UserInvitationHandlerEventTest {
 
   @Mock
   private UserInvitationService userInvitationService;
-
-  @Mock
-  private PersonalOrganizationService personalOrganizationService;
 
   @Mock
   private LinkGenerator linkGenerator;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic personal organization creation when users are created or activated through invitations.
  * Enhanced user deletion workflow to properly clean up associated personal organizations and projects with audit event publishing.

* **Tests**
  * Added tests validating user deletion behavior with personal organization cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->