### PR TITLE
EPMRPP-116480 || Fix error message for org integrations

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/organization/impl/OrganizationIntegrationHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/organization/impl/OrganizationIntegrationHandlerImpl.java
@@ -109,7 +109,7 @@ public class OrganizationIntegrationHandlerImpl implements OrganizationIntegrati
     validateOrganizationExists(orgId);
 
     IntegrationType integrationType = integrationTypeRepository.findByName(pluginName)
-        .orElseThrow(() -> new ReportPortalException(ErrorType.INTEGRATION_NOT_FOUND, pluginName));
+        .orElseThrow(() -> new ReportPortalException(ErrorType.INTEGRATION_TYPE_NOT_FOUND, pluginName));
 
     validateSingleInstanceTypeOrg(integrationType, orgId);
     String integrationName = ofNullable(createRequest.getName())
@@ -191,7 +191,7 @@ public class OrganizationIntegrationHandlerImpl implements OrganizationIntegrati
     List<Integration> integrations;
     if (StringUtils.isNotBlank(type)) {
       IntegrationType integrationType = integrationTypeRepository.findByName(type)
-          .orElseThrow(() -> new ReportPortalException(ErrorType.INTEGRATION_NOT_FOUND, type));
+          .orElseThrow(() -> new ReportPortalException(ErrorType.INTEGRATION_TYPE_NOT_FOUND, type));
       integrations = integrationRepository.findAllByOrganizationIdAndTypeId(orgId, integrationType.getId());
     } else {
       integrations = integrationRepository.findAllByOrganizationId(orgId, Pageable.unpaged()).toList();

--- a/src/main/java/com/epam/reportportal/base/exception/rest/StatusCodeMapping.java
+++ b/src/main/java/com/epam/reportportal/base/exception/rest/StatusCodeMapping.java
@@ -107,6 +107,7 @@ public class StatusCodeMapping {
 
       // ExternalSystem related
       put(ErrorType.INTEGRATION_NOT_FOUND, HttpStatus.NOT_FOUND);
+      put(ErrorType.INTEGRATION_TYPE_NOT_FOUND, HttpStatus.NOT_FOUND);
       put(ErrorType.INTEGRATION_ALREADY_EXISTS, HttpStatus.CONFLICT);
       put(ErrorType.PROJECT_NOT_CONFIGURED, HttpStatus.NOT_FOUND);
       put(ErrorType.INCORRECT_AUTHENTICATION_TYPE, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/epam/reportportal/base/infrastructure/rules/exception/ErrorType.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/rules/exception/ErrorType.java
@@ -225,6 +225,11 @@ public enum ErrorType {
   NOT_FOUND(40430, "'{}' not found. Did you use correct ID?"),
 
   /**
+   * If integration type not found
+   */
+  INTEGRATION_TYPE_NOT_FOUND(40431, "Integration type '{}' not found. Did you use correct type?"),
+
+  /**
    * If provided filtering parameters are incorrect
    */
   INCORRECT_FILTER_PARAMETERS(40011, "Incorrect filtering parameters. {}"),

--- a/src/test/java/com/epam/reportportal/base/core/organization/impl/OrganizationIntegrationHandlerImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/organization/impl/OrganizationIntegrationHandlerImplTest.java
@@ -152,7 +152,7 @@ class OrganizationIntegrationHandlerImplTest {
   }
 
   @Test
-  @DisplayName("Should throw INTEGRATION_NOT_FOUND when type does not exist")
+  @DisplayName("Should throw INTEGRATION_TYPE_NOT_FOUND when type does not exist")
   void deleteOrganizationIntegrationsWhenTypeNotFoundShouldThrow() {
     // Given
     mockedSecurityContextUtils.when(SecurityContextUtils::getPrincipal).thenReturn(principal);
@@ -162,7 +162,7 @@ class OrganizationIntegrationHandlerImplTest {
     // When & Then
     var ex = assertThrows(ReportPortalException.class,
         () -> handler.deleteOrganizationIntegrations(ORG_ID, "unknown"));
-    assertEquals(ErrorType.INTEGRATION_NOT_FOUND, ex.getErrorType());
+    assertEquals(ErrorType.INTEGRATION_TYPE_NOT_FOUND, ex.getErrorType());
   }
 
   @Test
@@ -266,6 +266,22 @@ class OrganizationIntegrationHandlerImplTest {
     // Then
     assertThat(result.getStatus()).isEqualTo(IntegrationConnectionStatus.StatusEnum.CONNECTED);
     assertThat(result.getCheckedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("Should throw INTEGRATION_TYPE_NOT_FOUND when plugin id does not exist")
+  void createOrganizationIntegrationWhenPluginIdNotFoundShouldThrow() {
+    // Given
+    when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(new Organization()));
+    when(integrationTypeRepository.findByName("unknown")).thenReturn(Optional.empty());
+
+    var request = new IntegrationRQ();
+    request.setName("email-server");
+
+    // When & Then
+    var ex = assertThrows(ReportPortalException.class,
+        () -> handler.createOrganizationIntegration(ORG_ID, "unknown", request));
+    assertEquals(ErrorType.INTEGRATION_TYPE_NOT_FOUND, ex.getErrorType());
   }
 
   @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid integration types—now returns a specific "Integration type not found" error when attempting to create or delete integrations with a non-existent type, with corresponding HTTP 404 status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->