### PR TITLE
EPMRPP-115024 || Add JWT revocation on logout and account deletion

### DIFF
--- a/project-properties.gradle
+++ b/project-properties.gradle
@@ -98,7 +98,7 @@ project.ext {
             (migrationsUrl + '/migrations/1000_tms_initial.up.sql')                    : 'V213__tms_initial.up.sql',
             (migrationsUrl + '/migrations/1001_migrate_auth_integrations.up.sql')      : 'V214__migrate_auth_integrations.up.sql',
             (migrationsUrl + '/migrations/1002_drop_tms_bts_ticket.up.sql')            : 'V215__drop_tms_bts_ticket.up.sql',
-            (migrationsUrl + '/migrations/1003_revoked_token.up.sql')                  : 'V216__revoked_token.up.sql'
+            (migrationsUrl + '/migrations/1004_revoked_token.up.sql')                  : 'V216__revoked_token.up.sql'
     ]
     excludeTests = ['**/entity/**',
                     '**/aop/**',

--- a/project-properties.gradle
+++ b/project-properties.gradle
@@ -16,7 +16,7 @@ project.ext {
     isDebugMode = System.getProperty("DEBUG", "false") == "true"
     releaseMode = project.hasProperty("releaseMode") ? project.releaseMode.toBoolean() : false
     scriptsUrl = commonScriptsUrl + (releaseMode ? '5.14.0' : 'develop')
-    migrationsUrl = migrationsScriptsUrl + (releaseMode ? '5.14.0' : 'develop')
+    migrationsUrl = migrationsScriptsUrl + (releaseMode ? '5.14.0' : 'EPMRPP-115024-blacklist-jwts')
     manifestSchemaUrl = schemaUrl + ('manifest.schema.json')
     //TODO refactor with archive download
     testScriptsSrc = [
@@ -98,6 +98,7 @@ project.ext {
             (migrationsUrl + '/migrations/1000_tms_initial.up.sql')                    : 'V213__tms_initial.up.sql',
             (migrationsUrl + '/migrations/1001_migrate_auth_integrations.up.sql')      : 'V214__migrate_auth_integrations.up.sql',
             (migrationsUrl + '/migrations/1002_drop_tms_bts_ticket.up.sql')            : 'V215__drop_tms_bts_ticket.up.sql',
+            (migrationsUrl + '/migrations/1003_revoked_token.up.sql')                  : 'V216__revoked_token.up.sql'
     ]
     excludeTests = ['**/entity/**',
                     '**/aop/**',

--- a/src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java
+++ b/src/main/java/com/epam/reportportal/auth/config/AuthorizationServerConfig.java
@@ -25,6 +25,7 @@ import com.epam.reportportal.auth.config.password.CustomCodeGrantAuthenticationC
 import com.epam.reportportal.auth.config.password.OAuth2ErrorResponseHandler;
 import com.epam.reportportal.auth.config.utils.JwtReportPortalUserConverter;
 import com.epam.reportportal.auth.store.MutableClientRegistrationRepository;
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ServerSettingsRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.ServerSettings;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
@@ -86,6 +87,7 @@ public class AuthorizationServerConfig {
   private final AuthenticationFailureHandler authenticationFailureHandler;
   private final PasswordEncoder passwordEncoder;
   private final UserDetailsService userDetailsService;
+  private final TokenBlacklistService tokenBlacklistService;
   private final DelegatingPluginAuthenticationProvider delegatingPluginAuthenticationProvider;
   private final DelegatingPluginOAuth2UserService delegatingPluginOAuth2UserService;
   @Value("${rp.jwt.signing-key}")
@@ -283,7 +285,7 @@ public class AuthorizationServerConfig {
     return oauth2 -> oauth2
         .jwt(jwt -> jwt
             .decoder(jwtDecoder())
-            .jwtAuthenticationConverter(new JwtReportPortalUserConverter(userDetailsService)));
+            .jwtAuthenticationConverter(new JwtReportPortalUserConverter(userDetailsService, tokenBlacklistService)));
   }
 
 }

--- a/src/main/java/com/epam/reportportal/auth/config/utils/JwtReportPortalUserConverter.java
+++ b/src/main/java/com/epam/reportportal/auth/config/utils/JwtReportPortalUserConverter.java
@@ -15,12 +15,15 @@
  */
 package com.epam.reportportal.auth.config.utils;
 
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import java.util.Collection;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 
@@ -33,12 +36,15 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
  */
 public class JwtReportPortalUserConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
-  private final static String PRINCIPAL_CLAIM_NAME = "user_name";
+  private static final String PRINCIPAL_CLAIM_NAME = "user_name";
   private final UserDetailsService userDetailsService;
+  private final TokenBlacklistService tokenBlacklistService;
   private final JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter;
 
-  public JwtReportPortalUserConverter(UserDetailsService userDetailsService) {
+  public JwtReportPortalUserConverter(UserDetailsService userDetailsService,
+      TokenBlacklistService tokenBlacklistService) {
     this.userDetailsService = userDetailsService;
+    this.tokenBlacklistService = tokenBlacklistService;
 
     this.jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
     this.jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("authorities");
@@ -47,16 +53,17 @@ public class JwtReportPortalUserConverter implements Converter<Jwt, AbstractAuth
 
   @Override
   public final AbstractAuthenticationToken convert(Jwt jwt) {
-    Collection<GrantedAuthority> authorities = this.jwtGrantedAuthoritiesConverter.convert(jwt);
+    if (tokenBlacklistService.isRevoked(jwt.getId(), jwt.getSubject(), jwt.getIssuedAt())) {
+      throw new OAuth2AuthenticationException(new OAuth2Error("invalid_token", "Token has been revoked", null));
+    }
 
+    Collection<GrantedAuthority> authorities = this.jwtGrantedAuthoritiesConverter.convert(jwt);
     String username = jwt.getClaimAsString(PRINCIPAL_CLAIM_NAME);
     String upstreamToken = jwt.getClaimAsString("upstream_token");
     var principal = userDetailsService.loadUserByUsername(username);
 
-    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
-        principal, null, authorities);
-    usernamePasswordAuthenticationToken.setDetails(upstreamToken);
-
-    return usernamePasswordAuthenticationToken;
+    var token = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+    token.setDetails(upstreamToken);
+    return token;
   }
 }

--- a/src/main/java/com/epam/reportportal/base/core/auth/LogoutHandler.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/LogoutHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.auth;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Performs the server-side actions required to log a user out of a JWT-authenticated session.
+ *
+ * <p>Implementations are expected to invalidate the supplied token so that any subsequent request
+ * carrying the same {@code jti} is rejected at authentication time.
+ */
+public interface LogoutHandler {
+
+  /**
+   * Invalidates the given JWT for all future requests.
+   *
+   * @param jwt the JWT that authenticated the current request; must expose a non-null {@code jti} and {@code exp}
+   */
+  void logout(Jwt jwt);
+}

--- a/src/main/java/com/epam/reportportal/base/core/auth/TokenBlacklistService.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/TokenBlacklistService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.auth;
+
+import java.time.Instant;
+
+/**
+ * JWT blacklist used to support immediate, server-side token revocation.
+ */
+public interface TokenBlacklistService {
+
+  /**
+   * Adds the given JWT identifier to the blacklist until its natural expiration.
+   *
+   * @param jti       JWT ID (the {@code jti} claim) of the token being revoked
+   * @param expiresAt original {@code exp} claim of the token; bounds the row's lifetime
+   */
+  void revoke(String jti, Instant expiresAt);
+
+  /**
+   * Revokes every currently active JWT issued to the given subject. JWTs whose {@code iat} is earlier than the moment
+   * this method is called will be rejected on the next request.
+   *
+   * @param subject JWT subject ({@code sub} claim) — typically the user's login or external id
+   */
+  void revokeSubject(String subject);
+
+  /**
+   * Checks whether a JWT identified by the given parameters has been revoked, either directly by {@code jti} or by a
+   * subject-level revocation that post-dates the JWT's {@code iat}.
+   *
+   * @param jti      JWT ID
+   * @param subject  JWT subject ({@code sub} claim)
+   * @param issuedAt JWT {@code iat} claim
+   * @return {@code true} if the JWT is revoked
+   */
+  boolean isRevoked(String jti, String subject, Instant issuedAt);
+}

--- a/src/main/java/com/epam/reportportal/base/core/auth/TokenBlacklistService.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/TokenBlacklistService.java
@@ -24,12 +24,11 @@ import java.time.Instant;
 public interface TokenBlacklistService {
 
   /**
-   * Adds the given JWT identifier to the blacklist until its natural expiration.
+   * Adds the given JWT identifier to the blacklist.
    *
-   * @param jti       JWT ID (the {@code jti} claim) of the token being revoked
-   * @param expiresAt original {@code exp} claim of the token; bounds the row's lifetime
+   * @param jti JWT ID (the {@code jti} claim) of the token being revoked
    */
-  void revoke(String jti, Instant expiresAt);
+  void revoke(String jti);
 
   /**
    * Revokes every currently active JWT issued to the given subject. JWTs whose {@code iat} is earlier than the moment

--- a/src/main/java/com/epam/reportportal/base/core/auth/impl/LogoutHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/impl/LogoutHandlerImpl.java
@@ -33,6 +33,6 @@ public class LogoutHandlerImpl implements LogoutHandler {
 
   @Override
   public void logout(Jwt jwt) {
-    tokenBlacklistService.revoke(jwt.getId(), jwt.getExpiresAt());
+    tokenBlacklistService.revoke(jwt.getId());
   }
 }

--- a/src/main/java/com/epam/reportportal/base/core/auth/impl/LogoutHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/impl/LogoutHandlerImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.auth.impl;
+
+import com.epam.reportportal.base.core.auth.LogoutHandler;
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default {@link LogoutHandler} that invalidates a JWT by adding its {@code jti} to the {@link TokenBlacklistService}.
+ */
+@Service
+@RequiredArgsConstructor
+public class LogoutHandlerImpl implements LogoutHandler {
+
+  private final TokenBlacklistService tokenBlacklistService;
+
+  @Override
+  public void logout(Jwt jwt) {
+    tokenBlacklistService.revoke(jwt.getId(), jwt.getExpiresAt());
+  }
+}

--- a/src/main/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImpl.java
@@ -19,10 +19,8 @@ package com.epam.reportportal.base.core.auth.impl;
 import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.RevokedToken;
-import java.time.Duration;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
  * JPA-backed implementation of {@link TokenBlacklistService}.
  *
  * <p>Per-token rows expire alongside their underlying JWT; per-user rows expire after the
- * configured access-token validity (no JWT issued before {@code revokeBefore} can outlive that window).
+ * configured access-token validity (no JWT issued before {@code revokedAt} can outlive that window).
  */
 @Service
 @RequiredArgsConstructor
@@ -38,21 +36,16 @@ public class TokenBlacklistServiceImpl implements TokenBlacklistService {
 
   private final RevokedTokenRepository revokedTokenRepository;
 
-  @Value("${rp.jwt.token.validity-period}")
-  private long accessTokenValiditySeconds;
-
   @Override
   @Transactional
-  public void revoke(String jti, Instant expiresAt) {
-    revokedTokenRepository.save(RevokedToken.forJti(jti, expiresAt));
+  public void revoke(String jti) {
+    revokedTokenRepository.save(RevokedToken.forJti(jti));
   }
 
   @Override
   @Transactional
   public void revokeSubject(String subject) {
-    var now = Instant.now();
-    var expiresAt = now.plus(Duration.ofSeconds(accessTokenValiditySeconds));
-    revokedTokenRepository.save(RevokedToken.forSubject(subject, now, expiresAt));
+    revokedTokenRepository.save(RevokedToken.forSubject(subject));
   }
 
   @Override

--- a/src/main/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImpl.java
@@ -21,6 +21,7 @@ import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRep
 import com.epam.reportportal.base.infrastructure.persistence.entity.RevokedToken;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,12 +40,18 @@ public class TokenBlacklistServiceImpl implements TokenBlacklistService {
   @Override
   @Transactional
   public void revoke(String jti) {
+    if (StringUtils.isBlank(jti)) {
+      throw new IllegalArgumentException("jti must not be blank");
+    }
     revokedTokenRepository.save(RevokedToken.forJti(jti));
   }
 
   @Override
   @Transactional
   public void revokeSubject(String subject) {
+    if (StringUtils.isBlank(subject)) {
+      throw new IllegalArgumentException("subject must not be blank");
+    }
     revokedTokenRepository.save(RevokedToken.forSubject(subject));
   }
 

--- a/src/main/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.auth.impl;
+
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
+import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.RevokedToken;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA-backed implementation of {@link TokenBlacklistService}.
+ *
+ * <p>Per-token rows expire alongside their underlying JWT; per-user rows expire after the
+ * configured access-token validity (no JWT issued before {@code revokeBefore} can outlive that window).
+ */
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistServiceImpl implements TokenBlacklistService {
+
+  private final RevokedTokenRepository revokedTokenRepository;
+
+  @Value("${rp.jwt.token.validity-period}")
+  private long accessTokenValiditySeconds;
+
+  @Override
+  @Transactional
+  public void revoke(String jti, Instant expiresAt) {
+    revokedTokenRepository.save(RevokedToken.forJti(jti, expiresAt));
+  }
+
+  @Override
+  @Transactional
+  public void revokeSubject(String subject) {
+    var now = Instant.now();
+    var expiresAt = now.plus(Duration.ofSeconds(accessTokenValiditySeconds));
+    revokedTokenRepository.save(RevokedToken.forSubject(subject, now, expiresAt));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public boolean isRevoked(String jti, String subject, Instant issuedAt) {
+    return revokedTokenRepository.isRevoked(jti, subject, issuedAt);
+  }
+}

--- a/src/main/java/com/epam/reportportal/base/core/configs/SchedulerConfiguration.java
+++ b/src/main/java/com/epam/reportportal/base/core/configs/SchedulerConfiguration.java
@@ -17,10 +17,11 @@
 package com.epam.reportportal.base.core.configs;
 
 import com.epam.reportportal.base.core.tms.scheduled.TmsAttachmentCleanupJob;
-import com.epam.reportportal.extension.classloader.ReportPortalResourceLoader;
 import com.epam.reportportal.base.job.CleanExpiredCreationBidsJob;
 import com.epam.reportportal.base.job.FlushingDataJob;
 import com.epam.reportportal.base.job.InterruptBrokenLaunchesJob;
+import com.epam.reportportal.base.job.RevokedTokensPurgeJob;
+import com.epam.reportportal.extension.classloader.ReportPortalResourceLoader;
 import jakarta.inject.Named;
 import java.time.Duration;
 import java.util.List;
@@ -132,6 +133,13 @@ public class SchedulerConfiguration {
   }
 
   @Bean
+  public SimpleTriggerFactoryBean revokedTokensPurgeTrigger(
+      @Named("revokedTokensPurgeJobBean") JobDetail jobDetail,
+      @Value("${com.ta.reportportal.job.purge.revoked.tokens.cron}") String purgeCron) {
+    return createTrigger(jobDetail, Duration.parse(purgeCron).toMillis());
+  }
+
+  @Bean
   @Profile("demo")
   public SimpleTriggerFactoryBean flushingDataTrigger(@Named("flushingDataJob") JobDetail jobDetail,
       @Value("${com.ta.reportportal.rp.flushing.time.cron}") String flushingCron) {
@@ -146,6 +154,11 @@ public class SchedulerConfiguration {
   @Bean("cleanExpiredCreationBidsJobBean")
   public JobDetailFactoryBean cleanExpiredCreationBidsJob() {
     return createJobDetail(CleanExpiredCreationBidsJob.class);
+  }
+
+  @Bean("revokedTokensPurgeJobBean")
+  public JobDetailFactoryBean revokedTokensPurgeJob() {
+    return createJobDetail(RevokedTokensPurgeJob.class);
   }
 
   @Bean

--- a/src/main/java/com/epam/reportportal/base/core/configs/security/MultiIdentityProviderConfig.java
+++ b/src/main/java/com/epam/reportportal/base/core/configs/security/MultiIdentityProviderConfig.java
@@ -20,6 +20,7 @@ import static com.epam.reportportal.base.core.configs.security.UserResolverType.
 
 import com.epam.reportportal.base.auth.userdetails.DefaultUserDetailsService;
 import com.epam.reportportal.base.auth.userdetails.ExternalUserDetailsService;
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.core.configs.security.converters.ExternalJwtConverter;
 import com.epam.reportportal.base.core.configs.security.converters.ReportPortalJwtConverter;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ServerSettingsRepository;
@@ -65,6 +66,7 @@ public class MultiIdentityProviderConfig {
   private final UserDetailsService userDetailsService;
   private final ExternalUserDetailsService externalUserDetailsService;
   private final ServerSettingsRepository serverSettingsRepository;
+  private final TokenBlacklistService tokenBlacklistService;
 
   /**
    * Constructs a MultiIdentityProviderConfig with the necessary services.
@@ -73,11 +75,13 @@ public class MultiIdentityProviderConfig {
   public MultiIdentityProviderConfig(
       DefaultUserDetailsService userDetailsService,
       ExternalUserDetailsService externalUserDetailsService,
-      ServerSettingsRepository serverSettingsRepository
+      ServerSettingsRepository serverSettingsRepository,
+      TokenBlacklistService tokenBlacklistService
   ) {
     this.userDetailsService = userDetailsService;
     this.externalUserDetailsService = externalUserDetailsService;
     this.serverSettingsRepository = serverSettingsRepository;
+    this.tokenBlacklistService = tokenBlacklistService;
   }
 
   /**
@@ -169,14 +173,14 @@ public class MultiIdentityProviderConfig {
 
   private Converter<Jwt, AbstractAuthenticationToken> createJwtConverter(String name, JwtIssuer config) {
     if (name.equals("rp")) {
-      return new ReportPortalJwtConverter(userDetailsService);
+      return new ReportPortalJwtConverter(userDetailsService, tokenBlacklistService);
     }
 
     var detailsService = config.getUserResolver() == EXTERNAL
         ? externalUserDetailsService
         : userDetailsService;
 
-    return new ExternalJwtConverter(detailsService, config);
+    return new ExternalJwtConverter(detailsService, tokenBlacklistService, config);
   }
 
   private SecretKeySpec convertToSecretKey(String key, String algorithm) {

--- a/src/main/java/com/epam/reportportal/base/core/configs/security/converters/AbstractJwtConverter.java
+++ b/src/main/java/com/epam/reportportal/base/core/configs/security/converters/AbstractJwtConverter.java
@@ -16,6 +16,7 @@
 
 package com.epam.reportportal.base.core.configs.security.converters;
 
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.core.configs.security.JwtIssuer;
 import java.util.Collection;
 import org.springframework.core.convert.converter.Converter;
@@ -24,6 +25,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 
@@ -37,6 +40,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
 public abstract class AbstractJwtConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
   protected final UserDetailsService userDetailsService;
+  protected final TokenBlacklistService tokenBlacklistService;
 
   protected JwtIssuer config;
 
@@ -45,37 +49,56 @@ public abstract class AbstractJwtConverter implements Converter<Jwt, AbstractAut
   /**
    * Constructs an AbstractJwtConverter with the specified UserDetailsService and default JwtIssuerConfig.
    *
-   * @param userDetailsService The service to load user details.
+   * @param userDetailsService    The service to load user details.
+   * @param tokenBlacklistService The service to for JWT blacklisting
    */
-  protected AbstractJwtConverter(UserDetailsService userDetailsService) {
-    this(userDetailsService, new JwtIssuer());
+  protected AbstractJwtConverter(UserDetailsService userDetailsService, TokenBlacklistService tokenBlacklistService) {
+    this(userDetailsService, tokenBlacklistService, new JwtIssuer());
   }
 
   /**
    * Constructs an AbstractJwtConverter with the specified UserDetailsService and JwtIssuerConfig.
    *
-   * @param userDetailsService The service to load user details.
-   * @param config             The configuration for JWT issuer settings.
+   * @param userDetailsService    The service to load user details.
+   * @param config                The configuration for JWT issuer settings.
+   * @param tokenBlacklistService The service to for JWT blacklisting
    */
-  protected AbstractJwtConverter(
-      UserDetailsService userDetailsService,
-      JwtIssuer config
-  ) {
+  protected AbstractJwtConverter(UserDetailsService userDetailsService, TokenBlacklistService tokenBlacklistService,
+      JwtIssuer config) {
     this.userDetailsService = userDetailsService;
+    this.tokenBlacklistService = tokenBlacklistService;
     this.config = config;
-    var jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
-    jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName(config.getAuthoritiesClaim());
-    jwtGrantedAuthoritiesConverter.setAuthorityPrefix("");
-    this.jwtGrantedAuthoritiesConverter = jwtGrantedAuthoritiesConverter;
+    var authoritiesConverter = new JwtGrantedAuthoritiesConverter();
+    authoritiesConverter.setAuthoritiesClaimName(config.getAuthoritiesClaim());
+    authoritiesConverter.setAuthorityPrefix("");
+    this.jwtGrantedAuthoritiesConverter = authoritiesConverter;
   }
 
   /**
-   * Finds a user by their identifier (username).
+   * Validates the JWT against the revocation blacklist and, if not revoked, delegates to the subclass-specific
+   * {@link #doConvert(Jwt)} to build the authentication token.
    *
-   * @param identifier The identifier of the user to find.
-   * @return The UserDetails of the found user.
-   * @throws UsernameNotFoundException if the user is not found.
+   * @param jwt decoded JWT
+   * @return authentication token for the resolved user
+   * @throws OAuth2AuthenticationException if the JWT's {@code jti} is present in the blacklist
    */
+  @Override
+  public final AbstractAuthenticationToken convert(Jwt jwt) {
+    if (tokenBlacklistService.isRevoked(jwt.getId(), jwt.getSubject(), jwt.getIssuedAt())) {
+      throw new OAuth2AuthenticationException(new OAuth2Error("invalid_token", "Token has been revoked", null));
+    }
+    return doConvert(jwt);
+  }
+
+  /**
+   * Subclass hook that builds the {@link AbstractAuthenticationToken} from a JWT that has already passed the revocation
+   * check.
+   *
+   * @param jwt decoded, non-revoked JWT
+   * @return authentication token for the resolved user
+   */
+  protected abstract AbstractAuthenticationToken doConvert(Jwt jwt);
+
   protected UserDetails findUser(String identifier) {
     try {
       return userDetailsService.loadUserByUsername(identifier);

--- a/src/main/java/com/epam/reportportal/base/core/configs/security/converters/ExternalJwtConverter.java
+++ b/src/main/java/com/epam/reportportal/base/core/configs/security/converters/ExternalJwtConverter.java
@@ -16,12 +16,12 @@
 
 package com.epam.reportportal.base.core.configs.security.converters;
 
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.core.configs.security.JwtIssuer;
 import java.util.Collection;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -34,15 +34,13 @@ import org.springframework.security.oauth2.jwt.Jwt;
  */
 public class ExternalJwtConverter extends AbstractJwtConverter {
 
-  /**
-   * Constructs an ExternalJwtConverter with the specified UserDetailsService and JWT issuer configuration.
-   */
-  public ExternalJwtConverter(UserDetailsService userDetailsService, JwtIssuer config) {
-    super(userDetailsService, config);
+  public ExternalJwtConverter(UserDetailsService userDetailsService,
+      TokenBlacklistService tokenBlacklistService, JwtIssuer config) {
+    super(userDetailsService, tokenBlacklistService, config);
   }
 
   @Override
-  public AbstractAuthenticationToken convert(Jwt jwt) {
+  protected AbstractAuthenticationToken doConvert(Jwt jwt) {
     var externalId = jwt.getClaimAsString(config.getUsernameClaim());
     if (StringUtils.isBlank(externalId)) {
       throw new IllegalArgumentException("Username claim is missing or null");
@@ -50,8 +48,8 @@ public class ExternalJwtConverter extends AbstractJwtConverter {
     var user = findUser(externalId);
     var authorities = Optional.ofNullable(extractAuthorities(jwt))
         .filter(auths -> !auths.isEmpty())
-        .orElseGet(() -> (Collection<GrantedAuthority>) findUser(externalId).getAuthorities());
+        .orElseGet(() -> (Collection<GrantedAuthority>) user.getAuthorities());
 
-    return new UsernamePasswordAuthenticationToken(user, null, authorities);
+    return new RpJwtAuthenticationToken(jwt, user, authorities);
   }
 }

--- a/src/main/java/com/epam/reportportal/base/core/configs/security/converters/ReportPortalJwtConverter.java
+++ b/src/main/java/com/epam/reportportal/base/core/configs/security/converters/ReportPortalJwtConverter.java
@@ -16,8 +16,8 @@
 
 package com.epam.reportportal.base.core.configs.security.converters;
 
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -29,19 +29,16 @@ import org.springframework.security.oauth2.jwt.Jwt;
  */
 public class ReportPortalJwtConverter extends AbstractJwtConverter {
 
-  /**
-   * Constructs a ReportPortalJwtConverter with the specified UserDetailsService.
-   */
-  public ReportPortalJwtConverter(UserDetailsService userDetailsService) {
-    super(userDetailsService);
+  public ReportPortalJwtConverter(UserDetailsService userDetailsService,
+      TokenBlacklistService tokenBlacklistService) {
+    super(userDetailsService, tokenBlacklistService);
   }
 
   @Override
-  public final AbstractAuthenticationToken convert(Jwt jwt) {
+  protected AbstractAuthenticationToken doConvert(Jwt jwt) {
     var username = jwt.getSubject();
     var principal = userDetailsService.loadUserByUsername(username);
     var authorities = extractAuthorities(jwt);
-
-    return new UsernamePasswordAuthenticationToken(principal, null, authorities);
+    return new RpJwtAuthenticationToken(jwt, principal, authorities);
   }
 }

--- a/src/main/java/com/epam/reportportal/base/core/configs/security/converters/RpJwtAuthenticationToken.java
+++ b/src/main/java/com/epam/reportportal/base/core/configs/security/converters/RpJwtAuthenticationToken.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.configs.security.converters;
+
+import java.util.Collection;
+import java.util.Objects;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * JWT-based {@link org.springframework.security.core.Authentication} that exposes the resolved {@link UserDetails} as
+ * the principal while preserving the underlying {@link Jwt} via {@link #getToken()}.
+ */
+public class RpJwtAuthenticationToken extends JwtAuthenticationToken {
+
+  private final UserDetails userDetails;
+
+  /**
+   * Creates a new authentication token for a successfully validated JWT.
+   *
+   * @param jwt         decoded and validated JWT bearer token
+   * @param userDetails resolved {@link UserDetails} for the JWT subject; exposed as the principal
+   * @param authorities granted authorities for the authenticated user
+   */
+  public RpJwtAuthenticationToken(Jwt jwt, UserDetails userDetails,
+      Collection<? extends GrantedAuthority> authorities) {
+    super(jwt, authorities, userDetails.getUsername());
+    this.userDetails = userDetails;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return userDetails;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RpJwtAuthenticationToken that)) {
+      return false;
+    }
+    return Objects.equals(getToken().getTokenValue(), that.getToken().getTokenValue())
+        && Objects.equals(userDetails, that.userDetails);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getToken().getTokenValue(), userDetails);
+  }
+}

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImpl.java
@@ -21,6 +21,7 @@ import static com.epam.reportportal.base.ws.converter.converters.ExceptionConver
 import com.epam.reportportal.base.core.events.domain.OrganizationDeletedEvent;
 import com.epam.reportportal.base.core.events.domain.ProjectDeletedEvent;
 import com.epam.reportportal.base.core.events.domain.UnassignUserEvent;
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.core.events.domain.UserDeletedEvent;
 import com.epam.reportportal.base.core.events.domain.UsersDeletedEvent;
 import com.epam.reportportal.base.core.project.settings.notification.ProjectRecipientHandler;
@@ -52,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -89,6 +91,8 @@ public class DeleteUserHandlerImpl implements DeleteUserHandler {
 
   private final ApplicationEventPublisher applicationEventPublisher;
 
+  private final TokenBlacklistService tokenBlacklistService;
+
   private static final String DELETED_USER = "deleted_user";
 
   @Value("${rp.environment.variable.allow-delete-account:false}")
@@ -124,9 +128,17 @@ public class DeleteUserHandlerImpl implements DeleteUserHandler {
 
     dataStore.deleteUserPhoto(user);
     userRepository.delete(user);
+    revokeUserTokens(user);
     sendEmailAboutDeletion(user, loggedInUser);
 
     return user;
+  }
+
+  private void revokeUserTokens(User user) {
+    tokenBlacklistService.revokeSubject(user.getLogin());
+    if (StringUtils.isNotBlank(user.getExternalId())) {
+      tokenBlacklistService.revokeSubject(user.getExternalId());
+    }
   }
 
   private void sendEmailAboutDeletion(User user, ReportPortalUser loggedInUser) {

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/RevokedTokenRepository.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/RevokedTokenRepository.java
@@ -45,18 +45,18 @@ public interface RevokedTokenRepository extends JpaRepository<RevokedToken, Long
       SELECT EXISTS (
           SELECT 1 FROM revoked_token
           WHERE jti = :jti
-             OR (subject = :subject AND revoke_before >= :issuedAt)
+             OR (subject = :subject AND revoked_at >= :issuedAt)
       )
       """, nativeQuery = true)
   boolean isRevoked(@Param("jti") String jti, @Param("subject") String subject, @Param("issuedAt") Instant issuedAt);
 
   /**
-   * Removes all blacklist rows whose {@code expiresAt} is in the past.
+   * Removes all blacklist rows whose {@code revokedAt} is older than the given cutoff.
    *
-   * @param now reference point; rows with {@code expiresAt < now} are deleted
+   * @param cutoff reference point; rows with {@code revokedAt < cutoff} are deleted
    */
   @Modifying
   @Transactional
-  @Query("DELETE FROM RevokedToken t WHERE t.expiresAt < :now")
-  void deleteExpired(Instant now);
+  @Query("DELETE FROM RevokedToken t WHERE t.revokedAt < :cutoff")
+  void deleteExpired(Instant cutoff);
 }

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/RevokedTokenRepository.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/RevokedTokenRepository.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.infrastructure.persistence.dao;
+
+import com.epam.reportportal.base.infrastructure.persistence.entity.RevokedToken;
+import java.time.Instant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA repository for {@link RevokedToken} entries. Supports both per-jti and per-subject lookups in a single query,
+ * plus a bulk delete used by the scheduled purge.
+ */
+@Repository
+public interface RevokedTokenRepository extends JpaRepository<RevokedToken, Long> {
+
+  /**
+   * Returns {@code true} if a JWT identified by the given parameters is revoked, either by an exact-jti match or by a
+   * per-subject revocation issued after the JWT was issued.
+   *
+   * @param jti      JWT ID
+   * @param subject  JWT subject (sub claim)
+   * @param issuedAt JWT {@code iat} claim
+   * @return {@code true} if any matching blacklist row exists
+   */
+  @Query(value = """
+      SELECT EXISTS (
+          SELECT 1 FROM revoked_token
+          WHERE jti = :jti
+             OR (subject = :subject AND revoke_before >= :issuedAt)
+      )
+      """, nativeQuery = true)
+  boolean isRevoked(@Param("jti") String jti, @Param("subject") String subject, @Param("issuedAt") Instant issuedAt);
+
+  /**
+   * Removes all blacklist rows whose {@code expiresAt} is in the past.
+   *
+   * @param now reference point; rows with {@code expiresAt < now} are deleted
+   */
+  @Modifying
+  @Transactional
+  @Query("DELETE FROM RevokedToken t WHERE t.expiresAt < :now")
+  void deleteExpired(Instant now);
+}

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/RevokedToken.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/RevokedToken.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * JWT blacklist row. Stores either a per-token revocation (by {@code jti}) or a per-user revocation (by JWT
+ * {@code subject} with a {@code revokeBefore} timestamp).
+ */
+@Entity
+@Table(name = "revoked_token", schema = "public")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RevokedToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "jti")
+  private String jti;
+
+  @Column(name = "subject")
+  private String subject;
+
+  @Column(name = "revoke_before")
+  private Instant revokeBefore;
+
+  @Column(name = "expires_at", nullable = false)
+  private Instant expiresAt;
+
+  /**
+   * Creates a per-token revocation row.
+   *
+   * @param jti       JWT ID of the revoked token
+   * @param expiresAt original {@code exp} of the JWT
+   */
+  public static RevokedToken forJti(String jti, Instant expiresAt) {
+    return new RevokedToken(null, jti, null, null, expiresAt);
+  }
+
+  /**
+   * Creates a per-user revocation row.
+   *
+   * @param subject      JWT {@code sub} claim of the user whose tokens are revoked
+   * @param revokeBefore JWTs with {@code iat < revokeBefore} are rejected
+   * @param expiresAt    row purge time (use now + max JWT lifetime)
+   */
+  public static RevokedToken forSubject(String subject, Instant revokeBefore, Instant expiresAt) {
+    return new RevokedToken(null, null, subject, revokeBefore, expiresAt);
+  }
+}

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/RevokedToken.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/RevokedToken.java
@@ -30,7 +30,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * JWT blacklist row. Stores either a per-token revocation (by {@code jti}) or a per-user revocation (by JWT
- * {@code subject} with a {@code revokeBefore} timestamp).
+ * {@code subject} with a {@code revokedAt} timestamp).
  */
 @Entity
 @Table(name = "revoked_token", schema = "public")
@@ -50,30 +50,24 @@ public class RevokedToken {
   @Column(name = "subject")
   private String subject;
 
-  @Column(name = "revoke_before")
-  private Instant revokeBefore;
-
-  @Column(name = "expires_at", nullable = false)
-  private Instant expiresAt;
+  @Column(name = "revoked_at", nullable = false)
+  private Instant revokedAt;
 
   /**
    * Creates a per-token revocation row.
    *
-   * @param jti       JWT ID of the revoked token
-   * @param expiresAt original {@code exp} of the JWT
+   * @param jti JWT ID of the revoked token
    */
-  public static RevokedToken forJti(String jti, Instant expiresAt) {
-    return new RevokedToken(null, jti, null, null, expiresAt);
+  public static RevokedToken forJti(String jti) {
+    return new RevokedToken(null, jti, null, Instant.now());
   }
 
   /**
    * Creates a per-user revocation row.
    *
-   * @param subject      JWT {@code sub} claim of the user whose tokens are revoked
-   * @param revokeBefore JWTs with {@code iat < revokeBefore} are rejected
-   * @param expiresAt    row purge time (use now + max JWT lifetime)
+   * @param subject JWT {@code sub} claim of the user whose tokens are revoked
    */
-  public static RevokedToken forSubject(String subject, Instant revokeBefore, Instant expiresAt) {
-    return new RevokedToken(null, null, subject, revokeBefore, expiresAt);
+  public static RevokedToken forSubject(String subject) {
+    return new RevokedToken(null, null, subject, Instant.now());
   }
 }

--- a/src/main/java/com/epam/reportportal/base/job/RevokedTokensPurgeJob.java
+++ b/src/main/java/com/epam/reportportal/base/job/RevokedTokensPurgeJob.java
@@ -17,11 +17,13 @@
 package com.epam.reportportal.base.job;
 
 import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
+import java.time.Duration;
 import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,13 +41,17 @@ public class RevokedTokensPurgeJob implements Job {
   @Autowired
   private RevokedTokenRepository revokedTokenRepository;
 
+  @Value("${rp.jwt.token.validity-period}")
+  private long accessTokenValiditySeconds;
+
   /**
-   * Deletes every blacklist row whose {@code expires_at} is already in the past.
+   * Deletes every blacklist row whose {@code revoked_at} is older than the maximum JWT lifetime.
    */
   @Override
   @Transactional
   public void execute(JobExecutionContext context) {
-    revokedTokenRepository.deleteExpired(Instant.now());
+    var cutoff = Instant.now().minus(Duration.ofSeconds(accessTokenValiditySeconds));
+    revokedTokenRepository.deleteExpired(cutoff);
     log.info("Purged expired entries from revoked_token table");
   }
 }

--- a/src/main/java/com/epam/reportportal/base/job/RevokedTokensPurgeJob.java
+++ b/src/main/java/com/epam/reportportal/base/job/RevokedTokensPurgeJob.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.job;
+
+import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Quartz job that removes expired entries from the JWT blacklist ({@code public.revoked_token} table).
+ *
+ * <p>Runs on the cluster-wide Quartz schedule configured in
+ * {@code com.ta.reportportal.job.purge.revoked.tokens.cron}, so only one service-api instance executes the purge per
+ * fire time.
+ */
+@Service
+@Slf4j
+public class RevokedTokensPurgeJob implements Job {
+
+  @Autowired
+  private RevokedTokenRepository revokedTokenRepository;
+
+  /**
+   * Deletes every blacklist row whose {@code expires_at} is already in the past.
+   */
+  @Override
+  @Transactional
+  public void execute(JobExecutionContext context) {
+    revokedTokenRepository.deleteExpired(Instant.now());
+    log.info("Purged expired entries from revoked_token table");
+  }
+}

--- a/src/main/java/com/epam/reportportal/base/ws/controller/AuthController.java
+++ b/src/main/java/com/epam/reportportal/base/ws/controller/AuthController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.ws.controller;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import com.epam.reportportal.base.core.auth.LogoutHandler;
+import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
+import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
+import com.epam.reportportal.base.reporting.OperationCompletionRS;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller exposing authentication-related operations that are not covered by the OAuth2 authorization service,
+ * currently the JWT logout endpoint.
+ */
+@RestController
+@RequestMapping("/v1/auth")
+@Tag(name = "Auth", description = "Authentication Controller")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final LogoutHandler logoutHandler;
+
+  @PostMapping("/logout")
+  @ResponseStatus(OK)
+  @Operation(summary = "Invalidate the current JWT token")
+  public OperationCompletionRS logout(Authentication authentication) {
+    if (!(authentication instanceof JwtAuthenticationToken jwtAuth)) {
+      throw new ReportPortalException(ErrorType.INCORRECT_REQUEST,
+          "Logout is supported for JWT-authenticated sessions only.");
+    }
+    logoutHandler.logout(jwtAuth.getToken());
+    return new OperationCompletionRS("Successfully logged out");
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,7 @@ com.ta.reportportal.job.load.plugins.cron=PT10S
 com.ta.reportportal.job.clean.outdated.plugins.cron=PT10S
 com.ta.reportportal.job.interrupt.broken.launches.cron=PT1H
 com.ta.reportportal.job.clean.bids.cron=PT1H
+com.ta.reportportal.job.purge.revoked.tokens.cron=PT24H
 spring.jooq.sql-dialect=POSTGRES
 
 

--- a/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
@@ -16,7 +16,11 @@
 
 package com.epam.reportportal.base.core.auth.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +34,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class TokenBlacklistServiceImplTest {
@@ -42,28 +45,25 @@ class TokenBlacklistServiceImplTest {
   private TokenBlacklistServiceImpl service;
 
   @Test
-  @DisplayName("Should persist a per-jti RevokedToken with the given jti and expiresAt")
+  @DisplayName("Should persist a per-jti RevokedToken with the given jti and revokedAt")
   void revokeWhenCalledShouldSavePerJtiRevokedToken() {
     // Given
     var jti = "abc-123";
-    var expiresAt = Instant.parse("2030-01-01T00:00:00Z");
     var captor = ArgumentCaptor.forClass(RevokedToken.class);
 
     // When
-    service.revoke(jti, expiresAt);
+    service.revoke(jti);
 
     // Then
     verify(revokedTokenRepository).save(captor.capture());
-    assertThat(captor.getValue())
-        .extracting("jti", "expiresAt")
-        .containsExactly(jti, expiresAt);
+    assertEquals(jti, captor.getValue().getJti());
+    assertNotNull(captor.getValue().getRevokedAt());
   }
 
   @Test
-  @DisplayName("Should persist a per-subject RevokedToken with subject and computed expiresAt")
+  @DisplayName("Should persist a per-subject RevokedToken with subject and revokedAt")
   void revokeSubjectWhenCalledShouldSavePerSubjectRevokedToken() {
     // Given
-    ReflectionTestUtils.setField(service, "accessTokenValiditySeconds", 3600L);
     var subject = "user@example.com";
     var captor = ArgumentCaptor.forClass(RevokedToken.class);
 
@@ -73,10 +73,9 @@ class TokenBlacklistServiceImplTest {
     // Then
     verify(revokedTokenRepository).save(captor.capture());
     var saved = captor.getValue();
-    assertThat(saved).extracting("subject").isEqualTo(subject);
-    assertThat(saved).extracting("jti").isNull();
-    assertThat(saved.getExpiresAt()).isAfter(Instant.now());
-    assertThat(saved.getRevokeBefore()).isNotNull();
+    assertEquals(subject, saved.getSubject());
+    assertNull(saved.getJti());
+    assertNotNull(saved.getRevokedAt());
   }
 
   @Test
@@ -92,7 +91,7 @@ class TokenBlacklistServiceImplTest {
     var result = service.isRevoked(jti, subject, issuedAt);
 
     // Then
-    assertThat(result).isTrue();
+    assertTrue(result);
     verify(revokedTokenRepository).isRevoked(jti, subject, issuedAt);
   }
 
@@ -109,7 +108,7 @@ class TokenBlacklistServiceImplTest {
     var result = service.isRevoked(jti, subject, issuedAt);
 
     // Then
-    assertThat(result).isFalse();
+    assertFalse(result);
     verify(revokedTokenRepository).isRevoked(jti, subject, issuedAt);
   }
 }

--- a/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,6 +77,18 @@ class TokenBlacklistServiceImplTest {
     assertEquals(subject, saved.getSubject());
     assertNull(saved.getJti());
     assertNotNull(saved.getRevokedAt());
+  }
+
+  @Test
+  @DisplayName("Should throw when jti is blank")
+  void revokeWhenJtiBlankShouldThrow() {
+    assertThrows(IllegalArgumentException.class, () -> service.revoke(" "));
+  }
+
+  @Test
+  @DisplayName("Should throw when subject is blank")
+  void revokeSubjectWhenSubjectBlankShouldThrow() {
+    assertThrows(IllegalArgumentException.class, () -> service.revokeSubject(null));
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.auth.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.RevokedToken;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TokenBlacklistServiceImplTest {
+
+  @Mock
+  private RevokedTokenRepository revokedTokenRepository;
+
+  @InjectMocks
+  private TokenBlacklistServiceImpl service;
+
+  @Test
+  @DisplayName("Should persist a per-jti RevokedToken with the given jti and expiresAt")
+  void revokeWhenCalledShouldSavePerJtiRevokedToken() {
+    // Given
+    var jti = "abc-123";
+    var expiresAt = Instant.parse("2030-01-01T00:00:00Z");
+    var captor = ArgumentCaptor.forClass(RevokedToken.class);
+
+    // When
+    service.revoke(jti, expiresAt);
+
+    // Then
+    verify(revokedTokenRepository).save(captor.capture());
+    assertThat(captor.getValue())
+        .extracting("jti", "expiresAt")
+        .containsExactly(jti, expiresAt);
+  }
+
+  @Test
+  @DisplayName("Should persist a per-subject RevokedToken with subject and computed expiresAt")
+  void revokeSubjectWhenCalledShouldSavePerSubjectRevokedToken() {
+    // Given
+    ReflectionTestUtils.setField(service, "accessTokenValiditySeconds", 3600L);
+    var subject = "user@example.com";
+    var captor = ArgumentCaptor.forClass(RevokedToken.class);
+
+    // When
+    service.revokeSubject(subject);
+
+    // Then
+    verify(revokedTokenRepository).save(captor.capture());
+    var saved = captor.getValue();
+    assertThat(saved).extracting("subject").isEqualTo(subject);
+    assertThat(saved).extracting("jti").isNull();
+    assertThat(saved.getExpiresAt()).isAfter(Instant.now());
+    assertThat(saved.getRevokeBefore()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("Should return true when token is revoked by jti or subject")
+  void isRevokedWhenMatchExistsShouldReturnTrue() {
+    // Given
+    var jti = "abc-123";
+    var subject = "user@example.com";
+    var issuedAt = Instant.parse("2026-01-01T00:00:00Z");
+    when(revokedTokenRepository.isRevoked(jti, subject, issuedAt)).thenReturn(true);
+
+    // When
+    var result = service.isRevoked(jti, subject, issuedAt);
+
+    // Then
+    assertThat(result).isTrue();
+    verify(revokedTokenRepository).isRevoked(jti, subject, issuedAt);
+  }
+
+  @Test
+  @DisplayName("Should return false when token is not revoked")
+  void isRevokedWhenNoMatchShouldReturnFalse() {
+    // Given
+    var jti = "abc-123";
+    var subject = "user@example.com";
+    var issuedAt = Instant.parse("2026-01-01T00:00:00Z");
+    when(revokedTokenRepository.isRevoked(jti, subject, issuedAt)).thenReturn(false);
+
+    // When
+    var result = service.isRevoked(jti, subject, issuedAt);
+
+    // Then
+    assertThat(result).isFalse();
+    verify(revokedTokenRepository).isRevoked(jti, subject, issuedAt);
+  }
+}

--- a/src/test/java/com/epam/reportportal/base/core/configs/security/converters/ReportPortalJwtConverterTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/configs/security/converters/ReportPortalJwtConverterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.configs.security.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+@ExtendWith(MockitoExtension.class)
+class ReportPortalJwtConverterTest {
+
+  @Mock
+  private UserDetailsService userDetailsService;
+
+  @Mock
+  private TokenBlacklistService tokenBlacklistService;
+
+  private ReportPortalJwtConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new ReportPortalJwtConverter(userDetailsService, tokenBlacklistService);
+  }
+
+  private static Jwt jwt(String jti, String subject) {
+    return Jwt.withTokenValue("token")
+        .header("alg", "HS256")
+        .subject(subject)
+        .jti(jti)
+        .issuedAt(Instant.parse("2026-01-01T00:00:00Z"))
+        .expiresAt(Instant.parse("2026-01-02T00:00:00Z"))
+        .claim("authorities", java.util.List.of("ROLE_USER"))
+        .build();
+  }
+
+  @Test
+  @DisplayName("Should produce RpJwtAuthenticationToken with UserDetails as principal and Jwt accessible")
+  void convertWhenValidJwtShouldReturnRpJwtAuthenticationToken() {
+    // Given
+    var jwt = jwt("jti-1", "user@reportportal.io");
+    UserDetails user = User.withUsername("user@reportportal.io")
+        .password("pwd")
+        .authorities(new SimpleGrantedAuthority("ROLE_USER"))
+        .build();
+    when(tokenBlacklistService.isRevoked("jti-1", "user@reportportal.io",
+        Instant.parse("2026-01-01T00:00:00Z"))).thenReturn(false);
+    when(userDetailsService.loadUserByUsername("user@reportportal.io")).thenReturn(user);
+
+    // When
+    var auth = converter.convert(jwt);
+
+    // Then
+    assertThat(auth).isInstanceOf(RpJwtAuthenticationToken.class);
+    var rpAuth = (RpJwtAuthenticationToken) auth;
+    assertThat(rpAuth.getPrincipal()).isSameAs(user);
+    assertThat(rpAuth.getToken()).isSameAs(jwt);
+    assertThat(rpAuth.getAuthorities())
+        .extracting("authority")
+        .containsExactly("ROLE_USER");
+  }
+
+  @Test
+  @DisplayName("Should throw OAuth2AuthenticationException when token is revoked")
+  void convertWhenTokenRevokedShouldThrow() {
+    // Given
+    var jwt = jwt("jti-revoked", "user@reportportal.io");
+    when(tokenBlacklistService.isRevoked("jti-revoked", "user@reportportal.io",
+        Instant.parse("2026-01-01T00:00:00Z"))).thenReturn(true);
+
+    // Then
+    assertThatThrownBy(() -> converter.convert(jwt))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessageContaining("revoked");
+  }
+}

--- a/src/test/java/com/epam/reportportal/base/core/configs/security/converters/ReportPortalJwtConverterTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/configs/security/converters/ReportPortalJwtConverterTest.java
@@ -16,8 +16,11 @@
 
 package com.epam.reportportal.base.core.configs.security.converters;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.epam.reportportal.base.core.auth.TokenBlacklistService;
@@ -79,13 +82,11 @@ class ReportPortalJwtConverterTest {
     var auth = converter.convert(jwt);
 
     // Then
-    assertThat(auth).isInstanceOf(RpJwtAuthenticationToken.class);
-    var rpAuth = (RpJwtAuthenticationToken) auth;
-    assertThat(rpAuth.getPrincipal()).isSameAs(user);
-    assertThat(rpAuth.getToken()).isSameAs(jwt);
-    assertThat(rpAuth.getAuthorities())
-        .extracting("authority")
-        .containsExactly("ROLE_USER");
+    var rpAuth = assertInstanceOf(RpJwtAuthenticationToken.class, auth);
+    assertSame(user, rpAuth.getPrincipal());
+    assertSame(jwt, rpAuth.getToken());
+    assertEquals(1, rpAuth.getAuthorities().size());
+    assertEquals("ROLE_USER", rpAuth.getAuthorities().iterator().next().getAuthority());
   }
 
   @Test
@@ -96,9 +97,10 @@ class ReportPortalJwtConverterTest {
     when(tokenBlacklistService.isRevoked("jti-revoked", "user@reportportal.io",
         Instant.parse("2026-01-01T00:00:00Z"))).thenReturn(true);
 
+    // When
+    var exception = assertThrows(OAuth2AuthenticationException.class, () -> converter.convert(jwt));
+
     // Then
-    assertThatThrownBy(() -> converter.convert(jwt))
-        .isInstanceOf(OAuth2AuthenticationException.class)
-        .hasMessageContaining("revoked");
+    assertTrue(exception.getMessage().contains("revoked"));
   }
 }

--- a/src/test/java/com/epam/reportportal/base/core/configs/security/converters/RpJwtAuthenticationTokenTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/configs/security/converters/RpJwtAuthenticationTokenTest.java
@@ -16,7 +16,9 @@
 
 package com.epam.reportportal.base.core.configs.security.converters;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.time.Instant;
 import java.util.List;
@@ -56,10 +58,10 @@ class RpJwtAuthenticationTokenTest {
     var token = new RpJwtAuthenticationToken(jwt, USER, authorities);
 
     // Then
-    assertThat(token.getPrincipal()).isSameAs(USER);
-    assertThat(token.getToken()).isSameAs(jwt);
-    assertThat(token.getAuthorities()).containsExactlyElementsOf(authorities);
-    assertThat(token.getName()).isEqualTo(USER.getUsername());
+    assertSame(USER, token.getPrincipal());
+    assertSame(jwt, token.getToken());
+    assertIterableEquals(authorities, token.getAuthorities());
+    assertEquals(USER.getUsername(), token.getName());
   }
 
   @Test
@@ -74,9 +76,9 @@ class RpJwtAuthenticationTokenTest {
     token.eraseCredentials();
 
     // Then
-    assertThat(token.getToken()).isSameAs(jwt);
-    assertThat(token.getToken().getId()).isEqualTo("jti-1");
-    assertThat(token.getToken().getExpiresAt()).isEqualTo(Instant.parse("2026-01-02T00:00:00Z"));
+    assertSame(jwt, token.getToken());
+    assertEquals("jti-1", token.getToken().getId());
+    assertEquals(Instant.parse("2026-01-02T00:00:00Z"), token.getToken().getExpiresAt());
   }
 
   @Test
@@ -96,6 +98,7 @@ class RpJwtAuthenticationTokenTest {
         List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
     // Then
-    assertThat(t1).isEqualTo(t2).hasSameHashCodeAs(t2);
+    assertEquals(t1, t2);
+    assertEquals(t1.hashCode(), t2.hashCode());
   }
 }

--- a/src/test/java/com/epam/reportportal/base/core/configs/security/converters/RpJwtAuthenticationTokenTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/configs/security/converters/RpJwtAuthenticationTokenTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.configs.security.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class RpJwtAuthenticationTokenTest {
+
+  private static final UserDetails USER = User.withUsername("user@reportportal.io")
+      .password("ignored")
+      .authorities(new SimpleGrantedAuthority("ROLE_USER"))
+      .build();
+
+  private static Jwt jwt() {
+    return Jwt.withTokenValue("token-value")
+        .header("alg", "HS256")
+        .claim("sub", "user@reportportal.io")
+        .jti("jti-1")
+        .issuedAt(Instant.parse("2026-01-01T00:00:00Z"))
+        .expiresAt(Instant.parse("2026-01-02T00:00:00Z"))
+        .build();
+  }
+
+  @Test
+  @DisplayName("Should expose UserDetails as principal and Jwt via getToken()")
+  void constructorShouldExposePrincipalAndToken() {
+    // Given
+    var jwt = jwt();
+    var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+    // When
+    var token = new RpJwtAuthenticationToken(jwt, USER, authorities);
+
+    // Then
+    assertThat(token.getPrincipal()).isSameAs(USER);
+    assertThat(token.getToken()).isSameAs(jwt);
+    assertThat(token.getAuthorities()).containsExactlyElementsOf(authorities);
+    assertThat(token.getName()).isEqualTo(USER.getUsername());
+  }
+
+  @Test
+  @DisplayName("Should preserve Jwt after eraseCredentials() so logout flow can read jti/exp")
+  void eraseCredentialsShouldNotNullifyTheJwt() {
+    // Given
+    var jwt = jwt();
+    var token = new RpJwtAuthenticationToken(jwt, USER,
+        List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+    // When
+    token.eraseCredentials();
+
+    // Then
+    assertThat(token.getToken()).isSameAs(jwt);
+    assertThat(token.getToken().getId()).isEqualTo("jti-1");
+    assertThat(token.getToken().getExpiresAt()).isEqualTo(Instant.parse("2026-01-02T00:00:00Z"));
+  }
+
+  @Test
+  @DisplayName("Should treat tokens with same JWT value and user as equal")
+  void equalsAndHashCodeShouldBeBasedOnTokenValueAndUser() {
+    // Given
+    var sharedJwt = jwt();
+    var sameJwtAgain = Jwt.withTokenValue("token-value")
+        .header("alg", "HS256")
+        .claim("sub", "user@reportportal.io")
+        .claims(claims -> claims.putAll(Map.of("foo", "bar")))
+        .jti("jti-1")
+        .build();
+    var t1 = new RpJwtAuthenticationToken(sharedJwt, USER,
+        List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    var t2 = new RpJwtAuthenticationToken(sameJwtAgain, USER,
+        List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+    // Then
+    assertThat(t1).isEqualTo(t2).hasSameHashCodeAs(t2);
+  }
+}

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImplTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.core.events.domain.OrganizationDeletedEvent;
 import com.epam.reportportal.base.core.events.domain.ProjectDeletedEvent;
 import com.epam.reportportal.base.core.events.domain.UserDeletedEvent;
@@ -97,6 +98,9 @@ class DeleteUserHandlerImplTest {
   @Mock
   private ApplicationEventPublisher applicationEventPublisher;
 
+  @Mock
+  private TokenBlacklistService tokenBlacklistService;
+
   @InjectMocks
   private DeleteUserHandlerImpl handler;
 
@@ -123,7 +127,33 @@ class DeleteUserHandlerImplTest {
 
     verify(repository, times(1)).findById(2L);
     verify(dataStore, times(1)).deleteUserPhoto(any());
+    verify(tokenBlacklistService).revokeSubject("test");
+  }
 
+  @Test
+  void deleteUserWithExternalIdShouldRevokeSubjectForBothLoginAndExternalId() {
+    User user = new User();
+    user.setId(2L);
+    user.setLogin("test");
+    user.setExternalId("ext-user-id");
+
+    doReturn(Optional.of(user)).when(repository).findById(2L);
+    when(organizationUserRepository.findNonPersonalOrganizationIdsByUserId(user.getId())).thenReturn(
+        Lists.newArrayList());
+    when(projectRepository.findAllByUserLogin(user.getLogin())).thenReturn(Lists.newArrayList());
+    when(organizationRepository.findByOwnerIdAndOrganizationType(user.getId(), OrganizationType.PERSONAL))
+        .thenReturn(Optional.empty());
+    doNothing().when(dataStore).deleteUserPhoto(any());
+    when(emailNotificationStrategyMapping.get(any())).thenReturn(emailNotificationStrategy);
+    doNothing().when(emailNotificationStrategy).sendEmail(any(), anyMap());
+    doNothing().when(applicationEventPublisher).publishEvent(isA(UserDeletedEvent.class));
+
+    handler.deleteUser(
+        2L, getRpUser("admin", UserRole.ADMINISTRATOR, OrganizationRole.MANAGER, ProjectRole.EDITOR,
+            1L));
+
+    verify(tokenBlacklistService).revokeSubject("test");
+    verify(tokenBlacklistService).revokeSubject("ext-user-id");
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/job/RevokedTokensPurgeJobTest.java
+++ b/src/test/java/com/epam/reportportal/base/job/RevokedTokensPurgeJobTest.java
@@ -16,11 +16,13 @@
 
 package com.epam.reportportal.base.job;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.verify;
 
 import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
+import java.time.Duration;
 import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,9 +30,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class RevokedTokensPurgeJobTest {
+
+  private static final long ACCESS_TOKEN_VALIDITY_SECONDS = 3600L;
 
   @Mock
   private RevokedTokenRepository revokedTokenRepository;
@@ -38,20 +43,25 @@ class RevokedTokensPurgeJobTest {
   @InjectMocks
   private RevokedTokensPurgeJob job;
 
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(job, "accessTokenValiditySeconds", ACCESS_TOKEN_VALIDITY_SECONDS);
+  }
+
   @Test
-  @DisplayName("Should call deleteExpired with the current Instant")
+  @DisplayName("Should call deleteExpired with cutoff based on token validity period")
   void executeShouldDeleteExpiredEntries() {
     // Given
     var captor = ArgumentCaptor.forClass(Instant.class);
-    var before = Instant.now();
+    var earliestCutoff = Instant.now().minus(Duration.ofSeconds(ACCESS_TOKEN_VALIDITY_SECONDS));
 
     // When
     job.execute(null);
 
     // Then
     verify(revokedTokenRepository).deleteExpired(captor.capture());
-    assertThat(captor.getValue())
-        .isAfterOrEqualTo(before)
-        .isBeforeOrEqualTo(Instant.now());
+    var cutoff = captor.getValue();
+    assertFalse(cutoff.isBefore(earliestCutoff));
+    assertFalse(cutoff.isAfter(Instant.now()));
   }
 }

--- a/src/test/java/com/epam/reportportal/base/job/RevokedTokensPurgeJobTest.java
+++ b/src/test/java/com/epam/reportportal/base/job/RevokedTokensPurgeJobTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RevokedTokensPurgeJobTest {
+
+  @Mock
+  private RevokedTokenRepository revokedTokenRepository;
+
+  @InjectMocks
+  private RevokedTokensPurgeJob job;
+
+  @Test
+  @DisplayName("Should call deleteExpired with the current Instant")
+  void executeShouldDeleteExpiredEntries() {
+    // Given
+    var captor = ArgumentCaptor.forClass(Instant.class);
+    var before = Instant.now();
+
+    // When
+    job.execute(null);
+
+    // Then
+    verify(revokedTokenRepository).deleteExpired(captor.capture());
+    assertThat(captor.getValue())
+        .isAfterOrEqualTo(before)
+        .isBeforeOrEqualTo(Instant.now());
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a REST `POST /v1/auth/logout` endpoint to invalidate the current JWT.
  * Introduced JWT revocation support during authentication, including revocation by token id and by subject.
  * Revoke tokens when users are deleted and periodically purge expired revocation records.

* **Chores**
  * Updated migration configuration and mapping for the revoked-token SQL script.

* **Tests**
  * Added/updated unit tests covering token revocation and the scheduled purge job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->