### PR TITLE
EPMRPP-116737 || Add cascading delete for project in OwnedEntity

### DIFF
--- a/project-properties.gradle
+++ b/project-properties.gradle
@@ -16,7 +16,7 @@ project.ext {
     isDebugMode = System.getProperty("DEBUG", "false") == "true"
     releaseMode = project.hasProperty("releaseMode") ? project.releaseMode.toBoolean() : false
     scriptsUrl = commonScriptsUrl + (releaseMode ? '5.14.0' : 'develop')
-    migrationsUrl = migrationsScriptsUrl + (releaseMode ? '5.14.0' : 'EPMRPP-115024-blacklist-jwts')
+    migrationsUrl = migrationsScriptsUrl + (releaseMode ? '5.14.0' : 'develop')
     manifestSchemaUrl = schemaUrl + ('manifest.schema.json')
     //TODO refactor with archive download
     testScriptsSrc = [

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/OwnedEntity.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/OwnedEntity.java
@@ -29,6 +29,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * JPA supertype for entities with an {@code owner} and optional {@link Project} link.
@@ -52,6 +54,7 @@ public abstract class OwnedEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "project_id")
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Project project;
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity by enforcing cascade delete for project-related entities at the database level when a project is removed.
* **Chores**
  * Updated migration script sourcing for non-release runs to use the `develop` branch/tag, ensuring migrations are pulled from the correct location outside release mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->