### PR TITLE
EPMRPP-117068 || Populate arguments.projectId as Long in plugin command execution

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/integration/impl/ExecuteIntegrationHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/integration/impl/ExecuteIntegrationHandlerImpl.java
@@ -33,6 +33,7 @@ import com.epam.reportportal.base.infrastructure.rules.commons.validation.Busine
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import com.epam.reportportal.base.reporting.OperationCompletionRS;
 import com.epam.reportportal.extension.ReportPortalExtensionPoint;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
@@ -147,12 +148,14 @@ public class ExecuteIntegrationHandlerImpl implements ExecuteIntegrationHandler 
         .orElseThrow(() -> new ReportPortalException(BAD_REQUEST_ERROR,
             formattedSupplier("Command '{}' is not found in plugin {}.", command, pluginName).get()
         ));
+    enrichArgumentsFromContext(pluginCommandRq);
     return pluginCommand.executeCommand(pluginCommandRq);
   }
 
 
   @Override
   public Object executeExtensionCommand(String pluginName, String command, PluginCommandRQ pluginCommandRq) {
+    enrichArgumentsFromContext(pluginCommandRq);
     ReportPortalExtensionPoint pluginInstance = pluginBox.getInstance(pluginName, ReportPortalExtensionPoint.class)
         .orElseThrow(() -> new ReportPortalException(BAD_REQUEST_ERROR,
             formattedSupplier("Plugin for '{}' isn't installed", pluginName).get()
@@ -171,6 +174,21 @@ public class ExecuteIntegrationHandlerImpl implements ExecuteIntegrationHandler 
     throw new ReportPortalException(BAD_REQUEST_ERROR,
         formattedSupplier("Command '{}' is not found in plugin {}.", command, pluginName).get()
     );
+  }
+
+  private void enrichArgumentsFromContext(PluginCommandRQ pluginCommandRq) {
+    var context = pluginCommandRq.getContext();
+    if (context == null) {
+      return;
+    }
+    var arguments = pluginCommandRq.getArguments();
+    if (arguments == null) {
+      arguments = new HashMap<>();
+      pluginCommandRq.setArguments(arguments);
+    }
+    if (context.getProjectId() != null) {
+      arguments.put(PROJECT_ID, context.getProjectId());
+    }
   }
 
   private Integration resolveIntegration(PluginCommandContext context) {


### PR DESCRIPTION
## Summary

Fixes HTTP 500 when executing plugin extension commands through `POST /api/plugins/{pluginName}/commands/{commandName}`.

The legacy common-command endpoint injected `projectId` into command parameters as `Long` from `MembershipDetails` before calling a plugin. The new `PluginCommandRQ` flow passes client-provided `arguments` as-is. JSON numeric values in `Map<String, Object>` are deserialized as `Integer`, while several BTS plugin commands (for example `getIssue`) cast `arguments.projectId` directly to `Long`, causing:

`class java.lang.Integer cannot be cast to class java.lang.Long`

This change restores the previous server-side behavior by copying `context.project_id` (typed as `Long`) into `arguments.projectId` before the plugin is invoked.

## Changes

- Add `enrichArgumentsFromContext` in `ExecuteIntegrationHandlerImpl`
- Call enrichment in `executeExtensionCommand` and `executeCommand(PluginCommandRQ)` before plugin execution
- When `context.project_id` is present, overwrite or set `arguments.projectId` with the `Long` value from context

## Related tickets

- EPMRPP-117068
- EPMRPP-115266 (UI migration to plugin commands API)

## Notes

This fix applies to all plugins that read `projectId` from command arguments via a `Long` cast. No per-plugin changes are required for the reported `getIssue` failure in GitLab, JIRA Cloud, and Monday integrations.

Should be deployed together with the service-ui migration to the new plugin commands endpoint for issue tooltips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Plugin command execution now properly enriches requests with necessary contextual information, ensuring project context is automatically included when executing integration plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->