### PR TITLE
EPMRPP-111876 || remove AWS SDK dependencies and update OpenDAL credential handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,6 @@ dependencies {
     implementation(libs.postgresql)
     jooqCodegen(libs.postgresql)
     implementation(libs.thumbnailator)
-    implementation(libs.aws.core)
-    implementation(libs.aws.sts)
     implementation(libs.jakarta.xml.bind.api)
     implementation(libs.jaxb.api)
     implementation(libs.json) // TODO get rid of

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ apache-commons-compress = "1.28.0"
 apache-commons-csv = "1.10.0"
 apache-commons-lang3 = "3.20.0"
 apache-poi = "5.5.0"
-aws-sdk = "2.41.3"
 bouncycastle = "1.84"
 commons-validator = "1.10.0"
 embedded-postgres = "2.2.0"
@@ -115,8 +114,6 @@ caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine" }
 postgresql = { group = "org.postgresql", name = "postgresql", version.ref = "jdbc-driver-version" }
 tika = { group = "org.apache.tika", name = "tika-core", version.ref = "tika" }
 thumbnailator = { group = "net.coobird", name = "thumbnailator", version.ref = "thumbnailator" }
-aws-core = { group = "software.amazon.awssdk", name = "aws-core", version.ref = "aws-sdk" }
-aws-sts = { group = "software.amazon.awssdk", name = "sts", version.ref = "aws-sdk" }
 jaxb-api = { group = "javax.xml.bind", name = "jaxb-api", version.ref = "jaxb-api" }
 jakarta-xml-bind-api = { group = "jakarta.xml.bind", name = "jakarta.xml.bind-api", version.ref = "jakarta-xml-bind-api" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }

--- a/src/main/java/com/epam/reportportal/base/core/configs/DataStoreConfiguration.java
+++ b/src/main/java/com/epam/reportportal/base/core/configs/DataStoreConfiguration.java
@@ -36,8 +36,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 /**
  * @author Dzianis_Shybeka
@@ -126,8 +124,9 @@ public class DataStoreConfiguration {
   /**
    * Creates OpenDAL Operator for AWS S3.
    *
-   * @param accessKey accessKey to use (optional, if not provided uses IAM credentials)
-   * @param secretKey secretKey to use (optional, if not provided uses IAM credentials)
+   * @param accessKey accessKey to use (optional, if not provided falls back to OpenDAL's built-in AWS default
+   *                  credential chain, which also handles IAM session-token credentials and their refresh)
+   * @param secretKey secretKey to use (optional, see {@code accessKey})
    * @param region    AWS S3 region to use.
    * @return {@link Operator}
    */
@@ -147,12 +146,6 @@ public class DataStoreConfiguration {
     if (StringUtils.isNotEmpty(accessKey) && StringUtils.isNotEmpty(secretKey)) {
       config.put(ACCESS_KEY_ID, accessKey);
       config.put(SECRET_ACCESS_KEY, secretKey);
-    } else {
-      // Use IAM credentials from DefaultCredentialsProvider
-      DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.builder().build();
-      AwsCredentials awsCredentials = credentialsProvider.resolveCredentials();
-      config.put(ACCESS_KEY_ID, awsCredentials.accessKeyId());
-      config.put(SECRET_ACCESS_KEY, awsCredentials.secretAccessKey());
     }
 
     return Operator.of("s3", config);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * AWS S3 connections now rely on OpenDAL’s built-in default credential handling when access keys are not explicitly provided.
  * Improved support for automatically managed credentials, including IAM session tokens and refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->