### PR TITLE
Fix EPMRPP-116970: TMS Manual Launches - Run Test fails from execution sidebar

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseExecutionServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseExecutionServiceImpl.java
@@ -3,7 +3,6 @@ package com.epam.reportportal.base.core.tms.service;
 import static com.epam.reportportal.base.infrastructure.rules.exception.ErrorType.NOT_FOUND;
 
 import com.epam.reportportal.base.core.item.TestItemService;
-import com.epam.reportportal.base.core.item.UpdateTestItemHandler;
 import com.epam.reportportal.base.core.item.FinishTestItemHandler;
 import com.epam.reportportal.base.core.tms.dto.NestedStepResult;
 import com.epam.reportportal.base.core.tms.dto.TmsManualLaunchExecutionStatisticRS;
@@ -34,7 +33,6 @@ import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestC
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import com.epam.reportportal.base.model.Page;
-import com.epam.reportportal.base.model.item.UpdateTestItemRQ;
 import com.epam.reportportal.base.reporting.FinishTestItemRQ;
 import com.epam.reportportal.base.ws.converter.PagedResourcesAssembler;
 import java.util.ArrayList;
@@ -71,7 +69,6 @@ public class TmsTestCaseExecutionServiceImpl implements TmsTestCaseExecutionServ
   private final TmsTestCaseExecutionRepository tmsTestCaseExecutionRepository;
   private final TmsTestCaseExecutionFilterableRepository tmsTestCaseExecutionFilterableRepository;
   private final TmsTestCaseVersionService tmsTestCaseVersionService;
-  private final UpdateTestItemHandler updateTestItemHandler;
   private final FinishTestItemHandler finishTestItemHandler;
   private final TmsTestCaseExecutionCommentService tmsTestCaseExecutionCommentService;
   private final TmsTestCaseExecutionMapper tmsTestCaseExecutionMapper;
@@ -613,14 +610,9 @@ public class TmsTestCaseExecutionServiceImpl implements TmsTestCaseExecutionServ
                 execution.setTestItem(testItem);
               } else {
                 // Terminal -> Terminal (Update logic)
-                execution.setTestItem(
-                    updateTestItemHandler.updateTestItem(
-                        membershipDetails,
-                        testItem,
-                        UpdateTestItemRQ.builder().status(request.getStatus()).build(),
-                        user
-                    )
-                );
+                testItem.getItemResults().setStatus(targetStatus);
+                testItem = testItemRepository.save(testItem);
+                execution.setTestItem(testItem);
               }
               // Add the test case to test plan for PASSED or FAILED status
               addTestCaseToTestPlan(execution, request.getStatus());

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseExecutionServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseExecutionServiceImplTest.java
@@ -209,7 +209,7 @@ class TmsTestCaseExecutionServiceImplTest {
   // ==================== patch: Terminal -> Terminal ====================
 
   @Test
-  void patch_WhenBothStatusesAreTerminal_ShouldCallUpdateTestItemHandler() {
+  void patch_WhenBothStatusesAreTerminal_ShouldSaveDirectlyAndBypassHandlers() {
     // Given - current FAILED, target PASSED → Terminal -> Terminal path
     var executionId = 100L;
     var launchId = 10L;
@@ -221,20 +221,18 @@ class TmsTestCaseExecutionServiceImplTest {
 
     when(tmsTestCaseExecutionRepository.findByTestCaseExecutionIdAndLaunchId(executionId, launchId))
         .thenReturn(Optional.of(execution1));
-    when(updateTestItemHandler.updateTestItem(
-        eq(membershipDetails), eq(testItem1), any(UpdateTestItemRQ.class), eq(user)))
-        .thenReturn(testItem1);
+    when(testItemRepository.save(any(TestItem.class))).thenReturn(testItem1);
     when(tmsTestCaseExecutionRepository.save(execution1)).thenReturn(execution1);
     when(tmsTestCaseExecutionMapper.convert(execution1)).thenReturn(new TmsTestCaseExecutionRS());
-    when(tmsManualLaunchService.getTestPlanIdByLaunchId(any())).thenReturn(Optional.empty());
 
     // When
     var result = sut.patch(membershipDetails, user, executionId, launchId, request);
 
     // Then
     assertNotNull(result);
-    verify(updateTestItemHandler).updateTestItem(
-        eq(membershipDetails), eq(testItem1), any(UpdateTestItemRQ.class), eq(user));
+    assertEquals(StatusEnum.PASSED, testItem1.getItemResults().getStatus());
+    verify(testItemRepository).save(testItem1);
+    verifyNoInteractions(updateTestItemHandler);
     verifyNoInteractions(finishTestItemHandler);
     verifyNoInteractions(testCaseItemBuilder);
   }


### PR DESCRIPTION
Fix EPMRPP-116970

Bypass the `hasChildren` guard in `TmsTestCaseExecutionServiceImpl.patch()` by updating the status directly (`testItem.getItemResults().setStatus(...)`) and saving it via the repository, as this guard is not applicable for TMS execution items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transitions between terminal test execution statuses.
  * Ensured the requested status is saved directly and reflected consistently in the test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->