### PR TITLE
Fix/EPMRPP-117032: Test plans duplicate under original milestone

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/tms/mapper/TmsTestPlanMapper.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/mapper/TmsTestPlanMapper.java
@@ -210,12 +210,12 @@ public abstract class TmsTestPlanMapper {
   @Mapping(target = "attributes", ignore = true)
   @Mapping(target = "launches", ignore = true)
   @Mapping(target = "testCases", ignore = true)
-  @Mapping(target = "project", source = "project")
-  @Mapping(target = "environment", source = "environment")
-  @Mapping(target = "productVersion", source = "productVersion")
-  @Mapping(target = "name", source = "name")
-  @Mapping(target = "description", source = "description")
-  @Mapping(target = "milestone", source = "milestone")
+  @Mapping(target = "project", source = "originalTestPlan.project")
+  @Mapping(target = "environment", source = "originalTestPlan.environment")
+  @Mapping(target = "productVersion", source = "originalTestPlan.productVersion")
+  @Mapping(target = "name", source = "originalTestPlan.name")
+  @Mapping(target = "description", source = "originalTestPlan.description")
+  @Mapping(target = "milestone", source = "targetMilestoneId", qualifiedByName = "milestoneIdToMilestone")
   @Mapping(target = "displayId", expression = "java(tmsDisplayIdService.generateTestPlanDisplayId(originalTestPlan.getProject().getId()))")
-  public abstract TmsTestPlan duplicateTestPlan(TmsTestPlan originalTestPlan);
+  public abstract TmsTestPlan duplicateTestPlan(TmsTestPlan originalTestPlan, Long targetMilestoneId);
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImpl.java
@@ -171,11 +171,11 @@ public class TmsMilestoneServiceImpl implements TmsMilestoneService {
     // Create a new milestone with data from request
     var newMilestone = tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ);
 
-    var duplicateTestPlansRS = tmsTestPlanService.duplicateTestPlansInMilestone(
-        projectId, milestoneId
-    );
-
     var savedMilestone = tmsMilestoneRepository.save(newMilestone);
+
+    var duplicateTestPlansRS = tmsTestPlanService.duplicateTestPlansInMilestone(
+        projectId, milestoneId, savedMilestone.getId()
+    );
 
     return tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(
         savedMilestone, duplicateTestPlansRS

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanService.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanService.java
@@ -32,7 +32,7 @@ public interface TmsTestPlanService extends CrudService<TmsTestPlanRQ, TmsTestPl
   DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId,
       TmsTestPlanRQ duplicateTestPlanRQ);
 
-  DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId);
+  DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId, Long targetMilestoneId);
 
   /**
    * Retrieves test cases added to a test plan with pagination. Returns test cases with last execution only (without
@@ -95,7 +95,7 @@ public interface TmsTestPlanService extends CrudService<TmsTestPlanRQ, TmsTestPl
 
   List<TmsTestPlanRS> getByMilestoneId(Long projectId, Long milestoneId);
 
-  List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(Long projectId, Long milestoneId);
+  List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(Long projectId, Long sourceMilestoneId, Long targetMilestoneId);
 
   void addTestPlanMilestone(Long projectId, Long milestoneId, Long testPlanId);
 

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImpl.java
@@ -301,7 +301,7 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
 
   @Override
   @Transactional
-  public DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId) {
+  public DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId, Long targetMilestoneId) {
     // Get original test plan
     var originalTestPlan = testPlanRepository
         .findByIdAndProjectId(testPlanId, projectId)
@@ -310,7 +310,7 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
         );
 
     // Duplicate test plan entity
-    var duplicatedTestPlan = tmsTestPlanMapper.duplicateTestPlan(originalTestPlan);
+    var duplicatedTestPlan = tmsTestPlanMapper.duplicateTestPlan(originalTestPlan, targetMilestoneId);
 
     duplicatedTestPlan = testPlanRepository.save(duplicatedTestPlan);
 
@@ -474,9 +474,9 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
   @Override
   @Transactional
   public List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(Long projectId,
-      Long milestoneId) {
+      Long sourceMilestoneId, Long targetMilestoneId) {
     var testPlanIds = testPlanRepository.findIdsByProjectIdAndMilestoneId(
-        projectId, milestoneId
+        projectId, sourceMilestoneId
     );
 
     if (testPlanIds.isEmpty()) {
@@ -484,7 +484,7 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
     }
     var result = new ArrayList<DuplicateTmsTestPlanRS>();
     for (var testPlanId : testPlanIds) {
-      var duplicatedTestPlanRS = duplicate(projectId, testPlanId);
+      var duplicatedTestPlanRS = duplicate(projectId, testPlanId, targetMilestoneId);
       result.add(duplicatedTestPlanRS);
     }
     return result;

--- a/src/test/java/com/epam/reportportal/base/core/tms/controller/integration/TmsMilestoneIntegrationTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/controller/integration/TmsMilestoneIntegrationTest.java
@@ -423,6 +423,8 @@ public class TmsMilestoneIntegrationTest extends BaseMvcTest {
     String jsonContent = objectMapper.writeValueAsString(duplicateRQ);
 
     long initialTestPlanCount = tmsTestPlanRepository.count();
+    long initialManualScenarioCount = countManualScenariosByMilestoneId(milestoneId);
+    long totalManualScenarioCountBeforeDuplication = countManualScenarios();
 
     // When/Then
     MvcResult result = mockMvc.perform(post("/v1/project/" + SUPERADMIN_PROJECT_KEY
@@ -446,6 +448,16 @@ public class TmsMilestoneIntegrationTest extends BaseMvcTest {
     String content = result.getResponse().getContentAsString();
     var duplicatedMilestone = objectMapper.readValue(content, DuplicateTmsMilestoneRS.class);
     assertEquals(3, duplicatedMilestone.getTestPlans().size());
+
+    // Verify duplicated test plans contain duplicated manual scenarios
+    long duplicatedMilestoneId = duplicatedMilestone.getId();
+    long duplicatedMilestoneManualScenarioCount = countManualScenariosByMilestoneId(
+        duplicatedMilestoneId);
+    long totalManualScenarioCountAfterDuplication = countManualScenarios();
+
+    assertEquals(initialManualScenarioCount, duplicatedMilestoneManualScenarioCount);
+    assertEquals(totalManualScenarioCountBeforeDuplication + initialManualScenarioCount,
+        totalManualScenarioCountAfterDuplication);
   }
 
   @Test
@@ -542,5 +554,27 @@ public class TmsMilestoneIntegrationTest extends BaseMvcTest {
         .andExpect(jsonPath("$.name").value("Custom Name"))
         .andExpect(jsonPath("$.status").value("TESTING"))
         .andExpect(jsonPath("$.type").value("SPRINT"));
+  }
+
+  private long countManualScenarios() {
+    var result = (Number) entityManager.createNativeQuery("""
+            SELECT COUNT(ms.id)
+            FROM tms_manual_scenario ms
+            """).getSingleResult();
+    return result.longValue();
+  }
+
+  private long countManualScenariosByMilestoneId(Long milestoneId) {
+    var result = (Number) entityManager.createNativeQuery("""
+            SELECT COUNT(ms.id)
+            FROM tms_manual_scenario ms
+            JOIN tms_test_case_version tcv ON tcv.id = ms.test_case_version_id
+            JOIN tms_test_plan_test_case tptc ON tptc.test_case_id = tcv.test_case_id
+            JOIN tms_test_plan tp ON tp.id = tptc.test_plan_id
+            WHERE tp.milestone_id = :milestoneId
+            """)
+        .setParameter("milestoneId", milestoneId)
+        .getSingleResult();
+    return result.longValue();
   }
 }

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImplTest.java
@@ -800,7 +800,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(duplicateTestPlansRS);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -818,7 +818,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId);
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         duplicateTestPlansRS);
@@ -840,7 +840,7 @@ class TmsMilestoneServiceImplTest {
     assertEquals(ErrorType.NOT_FOUND, exception.getErrorType());
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper, never()).toEntity(anyLong(), any());
-    verify(tmsTestPlanService, never()).duplicateTestPlansInMilestone(anyLong(), anyLong());
+    verify(tmsTestPlanService, never()).duplicateTestPlansInMilestone(anyLong(), anyLong(), anyLong());
     verify(tmsMilestoneRepository, never()).save(any());
   }
 
@@ -872,7 +872,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(emptyDuplicateTestPlans);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -890,7 +890,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId);
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         emptyDuplicateTestPlans);
@@ -928,7 +928,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(duplicateTestPlansRS);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -946,7 +946,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId);
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         duplicateTestPlansRS);

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -1056,7 +1057,7 @@ class TmsTestPlanServiceImplTest {
 
     when(testPlanRepository.findByIdAndProjectId(testPlanId, projectId))
         .thenReturn(Optional.of(originalTestPlan));
-    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan))
+    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan, (Long) null))
         .thenReturn(duplicatedTestPlan);
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
@@ -1078,13 +1079,13 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(expectedResponse);
 
     // When
-    var result = sut.duplicate(projectId, testPlanId);
+    var result = sut.duplicate(projectId, testPlanId, (Long) null);
 
     // Then
     assertNotNull(result);
     assertEquals(200L, result.getId());
     verify(testPlanRepository).findByIdAndProjectId(testPlanId, projectId);
-    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan);
+    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan, (Long) null);
     verify(testPlanRepository).save(duplicatedTestPlan);
     verify(tmsTestPlanAttributeService).duplicateTestPlanAttributes(originalTestPlan, duplicatedTestPlan);
     verify(tmsTestPlanTestCaseRepository).findTestCaseIdsByTestPlanId(testPlanId);
@@ -1115,7 +1116,7 @@ class TmsTestPlanServiceImplTest {
 
     when(testPlanRepository.findByIdAndProjectId(testPlanId, projectId))
         .thenReturn(Optional.of(originalTestPlan));
-    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan))
+    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan, (Long) null))
         .thenReturn(duplicatedTestPlan);
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
@@ -1126,13 +1127,13 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(expectedResponse);
 
     // When
-    var result = sut.duplicate(projectId, testPlanId);
+    var result = sut.duplicate(projectId, testPlanId, (Long) null);
 
     // Then
     assertNotNull(result);
     assertEquals(200L, result.getId());
     verify(testPlanRepository).findByIdAndProjectId(testPlanId, projectId);
-    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan);
+    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan, (Long) null);
     verify(testPlanRepository).save(duplicatedTestPlan);
     verify(tmsTestPlanAttributeService).duplicateTestPlanAttributes(originalTestPlan, duplicatedTestPlan);
     verify(tmsTestCaseService, never()).duplicateTestCases(anyLong(), anyList());
@@ -1147,12 +1148,12 @@ class TmsTestPlanServiceImplTest {
 
     // When/Then
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicate(projectId, testPlanId)
+        sut.duplicate(projectId, testPlanId, (Long) null)
     );
 
     assertEquals(ErrorType.NOT_FOUND, exception.getErrorType());
     verify(testPlanRepository).findByIdAndProjectId(testPlanId, projectId);
-    verify(tmsTestPlanMapper, never()).duplicateTestPlan(any(TmsTestPlan.class));
+    verify(tmsTestPlanMapper, never()).duplicateTestPlan(any(TmsTestPlan.class), nullable(Long.class));
     verify(testPlanRepository, never()).save(any());
   }
 
@@ -1631,7 +1632,8 @@ class TmsTestPlanServiceImplTest {
     // Setup for first duplicate call
     when(testPlanRepository.findByIdAndProjectId(testPlan1Id, projectId))
         .thenReturn(Optional.of(originalTestPlan1));
-    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan1))
+    Long targetMilestoneId = 999L;
+    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan1, targetMilestoneId))
         .thenReturn(duplicatedTestPlan1Entity);
     when(testPlanRepository.save(duplicatedTestPlan1Entity))
         .thenReturn(duplicatedTestPlan1Entity);
@@ -1645,7 +1647,7 @@ class TmsTestPlanServiceImplTest {
     // Setup for second duplicate call
     when(testPlanRepository.findByIdAndProjectId(testPlan2Id, projectId))
         .thenReturn(Optional.of(originalTestPlan2));
-    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan2))
+    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan2, targetMilestoneId))
         .thenReturn(duplicatedTestPlan2Entity);
     when(testPlanRepository.save(duplicatedTestPlan2Entity))
         .thenReturn(duplicatedTestPlan2Entity);
@@ -1655,7 +1657,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(duplicatedPlan2);
 
     // When
-    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId);
+    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId, targetMilestoneId);
 
     // Then
     assertNotNull(result);
@@ -1666,8 +1668,8 @@ class TmsTestPlanServiceImplTest {
     verify(testPlanRepository).findIdsByProjectIdAndMilestoneId(projectId, milestoneId);
     verify(testPlanRepository).findByIdAndProjectId(testPlan1Id, projectId);
     verify(testPlanRepository).findByIdAndProjectId(testPlan2Id, projectId);
-    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan1);
-    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan2);
+    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan1, targetMilestoneId);
+    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan2, targetMilestoneId);
   }
 
   @Test
@@ -1677,7 +1679,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(List.of());
 
     // When
-    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId);
+    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId, 999L);
 
     // Then
     assertNotNull(result);
@@ -1685,7 +1687,7 @@ class TmsTestPlanServiceImplTest {
 
     verify(testPlanRepository).findIdsByProjectIdAndMilestoneId(projectId, milestoneId);
     verify(testPlanRepository, never()).findByIdAndProjectId(anyLong(), anyLong());
-    verify(tmsTestPlanMapper, never()).duplicateTestPlan(any(TmsTestPlan.class));
+    verify(tmsTestPlanMapper, never()).duplicateTestPlan(any(TmsTestPlan.class), nullable(Long.class));
   }
 
   @Test


### PR DESCRIPTION
Fixes EPMRPP-117032: Copied test plans remain under source milestone instead of the new one.

Changes:
1. Updated `TmsMilestoneServiceImpl` so that `newMilestone` is saved before copying test plans. Thus obtaining the generated `targetMilestoneId`.
2. Passed `targetMilestoneId` down through `TmsTestPlanService.duplicateTestPlansInMilestone` and `TmsTestPlanService.duplicate`.
3. Updated `TmsTestPlanMapper.duplicateTestPlan` to accept `targetMilestoneId` and correctly assign it instead of inheriting the source milestone.
4. Adjusted tests accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test plans can now be duplicated directly into a specified milestone.
  * Duplicating a milestone now saves the new milestone first, then copies its test plans into it.
  * Test-plan duplication supports both individual plans and all plans from a source milestone.

* **Bug Fixes**
  * Improved milestone assignment during test-plan duplication to ensure copied plans belong to the newly created destination milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->