### PR TITLE
Remaining TMS tasks

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/tms/mapper/TmsTestPlanMapper.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/mapper/TmsTestPlanMapper.java
@@ -210,12 +210,12 @@ public abstract class TmsTestPlanMapper {
   @Mapping(target = "attributes", ignore = true)
   @Mapping(target = "launches", ignore = true)
   @Mapping(target = "testCases", ignore = true)
-  @Mapping(target = "project", source = "project")
-  @Mapping(target = "environment", source = "environment")
-  @Mapping(target = "productVersion", source = "productVersion")
-  @Mapping(target = "name", source = "name")
-  @Mapping(target = "description", source = "description")
-  @Mapping(target = "milestone", source = "milestone")
+  @Mapping(target = "project", source = "originalTestPlan.project")
+  @Mapping(target = "environment", source = "originalTestPlan.environment")
+  @Mapping(target = "productVersion", source = "originalTestPlan.productVersion")
+  @Mapping(target = "name", source = "originalTestPlan.name")
+  @Mapping(target = "description", source = "originalTestPlan.description")
+  @Mapping(target = "milestone", source = "targetMilestoneId", qualifiedByName = "milestoneIdToMilestone")
   @Mapping(target = "displayId", expression = "java(tmsDisplayIdService.generateTestPlanDisplayId(originalTestPlan.getProject().getId()))")
-  public abstract TmsTestPlan duplicateTestPlan(TmsTestPlan originalTestPlan);
+  public abstract TmsTestPlan duplicateTestPlan(TmsTestPlan originalTestPlan, Long targetMilestoneId);
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsManualLaunchServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsManualLaunchServiceImpl.java
@@ -211,9 +211,14 @@ public class TmsManualLaunchServiceImpl implements TmsManualLaunchService {
     var projectId = membershipDetails.getProjectId();
     log.debug("Deleting manual launch: {} for project: {}", launchId, projectId);
 
-    if (!launchRepository.existsByIdAndProjectId(launchId, projectId)) {
-      throw new ReportPortalException(
-          NOT_FOUND, LAUNCH_NOT_FOUND_BY_ID.formatted(launchId, projectId));
+    var launch = launchRepository.findManualLaunchByIdAndProjectId(launchId, projectId)
+        .orElseThrow(() -> new ReportPortalException(
+            NOT_FOUND, LAUNCH_NOT_FOUND_BY_ID.formatted(launchId, projectId))
+        );
+
+    if (StatusEnum.IN_PROGRESS.equals(launch.getStatus())) {
+      launch.setStatus(StatusEnum.INTERRUPTED);
+      launchRepository.save(launch);
     }
 
     // Delete tms step executions
@@ -497,14 +502,20 @@ public class TmsManualLaunchServiceImpl implements TmsManualLaunchService {
     for (var launchId : launchIds) {
       try {
         // Check if launch exists and belongs to project
-        if (!launchRepository.existsByIdAndProjectIdAndLaunchType(launchId, projectId,
-            LaunchTypeEnum.MANUAL)) {
+        var launchOptional = launchRepository.findManualLaunchByIdAndProjectId(launchId, projectId);
+        if (launchOptional.isEmpty()) {
           log.warn("Launch {} not found in project {}", launchId, projectId);
           errors.add(new BatchManualLaunchOperationError(
               launchId,
               "Manual Launch not found in project"
           ));
           continue;
+        }
+        var launch = launchOptional.get();
+
+        if (StatusEnum.IN_PROGRESS.equals(launch.getStatus())) {
+          launch.setStatus(StatusEnum.INTERRUPTED);
+          launchRepository.save(launch);
         }
 
         // Delete tms step executions

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImpl.java
@@ -171,11 +171,11 @@ public class TmsMilestoneServiceImpl implements TmsMilestoneService {
     // Create a new milestone with data from request
     var newMilestone = tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ);
 
-    var duplicateTestPlansRS = tmsTestPlanService.duplicateTestPlansInMilestone(
-        projectId, milestoneId
-    );
-
     var savedMilestone = tmsMilestoneRepository.save(newMilestone);
+
+    var duplicateTestPlansRS = tmsTestPlanService.duplicateTestPlansInMilestone(
+        projectId, milestoneId, savedMilestone.getId()
+    );
 
     return tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(
         savedMilestone, duplicateTestPlansRS

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanService.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanService.java
@@ -32,7 +32,7 @@ public interface TmsTestPlanService extends CrudService<TmsTestPlanRQ, TmsTestPl
   DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId,
       TmsTestPlanRQ duplicateTestPlanRQ);
 
-  DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId);
+  DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId, Long targetMilestoneId);
 
   /**
    * Retrieves test cases added to a test plan with pagination. Returns test cases with last execution only (without
@@ -95,7 +95,7 @@ public interface TmsTestPlanService extends CrudService<TmsTestPlanRQ, TmsTestPl
 
   List<TmsTestPlanRS> getByMilestoneId(Long projectId, Long milestoneId);
 
-  List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(Long projectId, Long milestoneId);
+  List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(Long projectId, Long sourceMilestoneId, Long targetMilestoneId);
 
   void addTestPlanMilestone(Long projectId, Long milestoneId, Long testPlanId);
 

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImpl.java
@@ -301,7 +301,7 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
 
   @Override
   @Transactional
-  public DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId) {
+  public DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId, Long targetMilestoneId) {
     // Get original test plan
     var originalTestPlan = testPlanRepository
         .findByIdAndProjectId(testPlanId, projectId)
@@ -310,7 +310,7 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
         );
 
     // Duplicate test plan entity
-    var duplicatedTestPlan = tmsTestPlanMapper.duplicateTestPlan(originalTestPlan);
+    var duplicatedTestPlan = tmsTestPlanMapper.duplicateTestPlan(originalTestPlan, targetMilestoneId);
 
     duplicatedTestPlan = testPlanRepository.save(duplicatedTestPlan);
 
@@ -474,9 +474,9 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
   @Override
   @Transactional
   public List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(Long projectId,
-      Long milestoneId) {
+      Long sourceMilestoneId, Long targetMilestoneId) {
     var testPlanIds = testPlanRepository.findIdsByProjectIdAndMilestoneId(
-        projectId, milestoneId
+        projectId, sourceMilestoneId
     );
 
     if (testPlanIds.isEmpty()) {
@@ -484,7 +484,7 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
     }
     var result = new ArrayList<DuplicateTmsTestPlanRS>();
     for (var testPlanId : testPlanIds) {
-      var duplicatedTestPlanRS = duplicate(projectId, testPlanId);
+      var duplicatedTestPlanRS = duplicate(projectId, testPlanId, targetMilestoneId);
       result.add(duplicatedTestPlanRS);
     }
     return result;

--- a/src/test/java/com/epam/reportportal/base/core/tms/controller/integration/TmsManualLaunchIntegrationTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/controller/integration/TmsManualLaunchIntegrationTest.java
@@ -26,6 +26,7 @@ import com.epam.reportportal.base.core.tms.dto.TmsTestCaseExecutionRQ;
 import com.epam.reportportal.base.core.tms.dto.TmsTestCaseExecutionRS;
 import com.epam.reportportal.base.core.tms.dto.UploadAttachmentRS;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchAddTestCasesToLaunchRQ;
+import com.epam.reportportal.base.core.tms.dto.batch.BatchDeleteManualLaunchesRQ;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchDeleteTestCaseExecutionsRQ;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchDeleteTestCaseExecutionsResultRS;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchTestCaseOperationResultRS;
@@ -612,6 +613,39 @@ public class TmsManualLaunchIntegrationTest extends BaseMvcTest {
                 .content(mapper.writeValueAsString(patchRQ))
                 .with(token(oAuthHelper.getSuperadminToken())))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteManualLaunch_InProgress_ShouldSucceed() throws Exception {
+    // When
+    mockMvc.perform(
+            delete("/v1/project/" + SUPERADMIN_PROJECT_KEY + "/launch/manual/202")
+                .with(token(oAuthHelper.getSuperadminToken())))
+        .andExpect(status().isOk());
+
+    // Then
+    var launch = launchRepository.findById(202L);
+    assertTrue(launch.isEmpty());
+  }
+
+  @Test
+  void batchDeleteManualLaunches_InProgress_ShouldSucceed() throws Exception {
+    // Given
+    var batchDeleteRQ = BatchDeleteManualLaunchesRQ.builder()
+        .launchIds(List.of(202L))
+        .build();
+
+    // When
+    mockMvc.perform(
+            delete("/v1/project/" + SUPERADMIN_PROJECT_KEY + "/launch/manual")
+                .contentType(APPLICATION_JSON)
+                .content(mapper.writeValueAsString(batchDeleteRQ))
+                .with(token(oAuthHelper.getSuperadminToken())))
+        .andExpect(status().isOk());
+
+    // Then
+    var launch = launchRepository.findById(202L);
+    assertTrue(launch.isEmpty());
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/core/tms/controller/integration/TmsMilestoneIntegrationTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/controller/integration/TmsMilestoneIntegrationTest.java
@@ -423,6 +423,8 @@ public class TmsMilestoneIntegrationTest extends BaseMvcTest {
     String jsonContent = objectMapper.writeValueAsString(duplicateRQ);
 
     long initialTestPlanCount = tmsTestPlanRepository.count();
+    long initialManualScenarioCount = countManualScenariosByMilestoneId(milestoneId);
+    long totalManualScenarioCountBeforeDuplication = countManualScenarios();
 
     // When/Then
     MvcResult result = mockMvc.perform(post("/v1/project/" + SUPERADMIN_PROJECT_KEY
@@ -446,6 +448,16 @@ public class TmsMilestoneIntegrationTest extends BaseMvcTest {
     String content = result.getResponse().getContentAsString();
     var duplicatedMilestone = objectMapper.readValue(content, DuplicateTmsMilestoneRS.class);
     assertEquals(3, duplicatedMilestone.getTestPlans().size());
+
+    // Verify duplicated test plans contain duplicated manual scenarios
+    long duplicatedMilestoneId = duplicatedMilestone.getId();
+    long duplicatedMilestoneManualScenarioCount = countManualScenariosByMilestoneId(
+        duplicatedMilestoneId);
+    long totalManualScenarioCountAfterDuplication = countManualScenarios();
+
+    assertEquals(initialManualScenarioCount, duplicatedMilestoneManualScenarioCount);
+    assertEquals(totalManualScenarioCountBeforeDuplication + initialManualScenarioCount,
+        totalManualScenarioCountAfterDuplication);
   }
 
   @Test
@@ -542,5 +554,27 @@ public class TmsMilestoneIntegrationTest extends BaseMvcTest {
         .andExpect(jsonPath("$.name").value("Custom Name"))
         .andExpect(jsonPath("$.status").value("TESTING"))
         .andExpect(jsonPath("$.type").value("SPRINT"));
+  }
+
+  private long countManualScenarios() {
+    var result = (Number) entityManager.createNativeQuery("""
+            SELECT COUNT(ms.id)
+            FROM tms_manual_scenario ms
+            """).getSingleResult();
+    return result.longValue();
+  }
+
+  private long countManualScenariosByMilestoneId(Long milestoneId) {
+    var result = (Number) entityManager.createNativeQuery("""
+            SELECT COUNT(ms.id)
+            FROM tms_manual_scenario ms
+            JOIN tms_test_case_version tcv ON tcv.id = ms.test_case_version_id
+            JOIN tms_test_plan_test_case tptc ON tptc.test_case_id = tcv.test_case_id
+            JOIN tms_test_plan tp ON tp.id = tptc.test_plan_id
+            WHERE tp.milestone_id = :milestoneId
+            """)
+        .setParameter("milestoneId", milestoneId)
+        .getSingleResult();
+    return result.longValue();
   }
 }

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsManualLaunchServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsManualLaunchServiceImplTest.java
@@ -23,6 +23,7 @@ import com.epam.reportportal.base.core.tms.dto.TmsManualLaunchRS;
 import com.epam.reportportal.base.core.tms.dto.TmsManualLaunchTestPlanRQ;
 import com.epam.reportportal.base.core.tms.dto.TmsTestCaseExecutionCommentRQ;
 import com.epam.reportportal.base.core.tms.dto.TmsTestCaseExecutionCommentRS;
+import com.epam.reportportal.base.core.tms.dto.batch.BatchDeleteManualLaunchesRQ;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchTestCaseOperationResultRS;
 import com.epam.reportportal.base.core.tms.mapper.TmsManualLaunchMapper;
 import com.epam.reportportal.base.core.user.GetUserHandler;
@@ -218,12 +219,16 @@ class TmsManualLaunchServiceImplTest {
 
   @Test
   void delete_WhenLaunchExists_ShouldDeleteAllRelatedDataAndLaunch() {
-    when(launchRepository.existsByIdAndProjectId(launchId, projectId)).thenReturn(true);
+    launch.setStatus(StatusEnum.IN_PROGRESS);
+    when(launchRepository.findManualLaunchByIdAndProjectId(launchId, projectId))
+        .thenReturn(Optional.of(launch));
     when(membershipDetails.getProjectId()).thenReturn(projectId);
   
     sut.delete(membershipDetails, launchId, user);
 
-    verify(launchRepository).existsByIdAndProjectId(launchId, projectId);
+    assertEquals(StatusEnum.INTERRUPTED, launch.getStatus());
+    verify(launchRepository).findManualLaunchByIdAndProjectId(launchId, projectId);
+    verify(launchRepository).save(launch);
     verify(tmsStepExecutionService).deleteByLaunchId(launchId);
     verify(tmsTestCaseExecutionService).deleteByLaunchId(launchId);
     verify(testFolderItemService).deleteByLaunchId(launchId);
@@ -235,13 +240,34 @@ class TmsManualLaunchServiceImplTest {
   @Test
   void delete_WhenLaunchDoesNotExist_ShouldThrowNotFoundException() {
     when(membershipDetails.getProjectId()).thenReturn(projectId);
-    when(launchRepository.existsByIdAndProjectId(launchId, projectId)).thenReturn(false);
+    when(launchRepository.findManualLaunchByIdAndProjectId(launchId, projectId))
+        .thenReturn(Optional.empty());
   
     var exception = assertThrows(ReportPortalException.class,
         () -> sut.delete(membershipDetails, launchId, user));
     assertEquals(NOT_FOUND, exception.getErrorType());
   
     verify(deleteLaunchHandler, never()).deleteLaunch(anyLong(), any(), any());
+  }
+
+  @Test
+  void batchDeleteManualLaunches_WhenLaunchesExist_ShouldInterruptInProgressAndCallDelete() {
+    launch.setStatus(StatusEnum.IN_PROGRESS);
+    when(membershipDetails.getProjectId()).thenReturn(projectId);
+    when(launchRepository.findManualLaunchByIdAndProjectId(launchId, projectId))
+        .thenReturn(Optional.of(launch));
+
+    sut.batchDeleteManualLaunches(membershipDetails, new BatchDeleteManualLaunchesRQ(List.of(launchId)), user);
+
+    assertEquals(StatusEnum.INTERRUPTED, launch.getStatus());
+    verify(launchRepository).findManualLaunchByIdAndProjectId(launchId, projectId);
+    verify(launchRepository).save(launch);
+    verify(tmsStepExecutionService).deleteByLaunchId(launchId);
+    verify(tmsTestCaseExecutionService).deleteByLaunchId(launchId);
+    verify(testFolderItemService).deleteByLaunchId(launchId);
+    verify(testItemService).deleteByLaunchId(projectId, launchId);
+    verify(tmsManualLaunchAttributeService).deleteAllByLaunchId(launchId);
+    verify(deleteLaunchHandler).deleteLaunch(launchId, membershipDetails, user);
   }
 
   // -------------------------------------------------------------------------

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImplTest.java
@@ -800,7 +800,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(duplicateTestPlansRS);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -818,7 +818,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId);
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         duplicateTestPlansRS);
@@ -840,7 +840,7 @@ class TmsMilestoneServiceImplTest {
     assertEquals(ErrorType.NOT_FOUND, exception.getErrorType());
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper, never()).toEntity(anyLong(), any());
-    verify(tmsTestPlanService, never()).duplicateTestPlansInMilestone(anyLong(), anyLong());
+    verify(tmsTestPlanService, never()).duplicateTestPlansInMilestone(anyLong(), anyLong(), anyLong());
     verify(tmsMilestoneRepository, never()).save(any());
   }
 
@@ -872,7 +872,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(emptyDuplicateTestPlans);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -890,7 +890,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId);
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         emptyDuplicateTestPlans);
@@ -928,7 +928,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(duplicateTestPlansRS);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -946,7 +946,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId);
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         duplicateTestPlansRS);

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -1056,7 +1057,7 @@ class TmsTestPlanServiceImplTest {
 
     when(testPlanRepository.findByIdAndProjectId(testPlanId, projectId))
         .thenReturn(Optional.of(originalTestPlan));
-    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan))
+    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan, (Long) null))
         .thenReturn(duplicatedTestPlan);
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
@@ -1078,13 +1079,13 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(expectedResponse);
 
     // When
-    var result = sut.duplicate(projectId, testPlanId);
+    var result = sut.duplicate(projectId, testPlanId, (Long) null);
 
     // Then
     assertNotNull(result);
     assertEquals(200L, result.getId());
     verify(testPlanRepository).findByIdAndProjectId(testPlanId, projectId);
-    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan);
+    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan, (Long) null);
     verify(testPlanRepository).save(duplicatedTestPlan);
     verify(tmsTestPlanAttributeService).duplicateTestPlanAttributes(originalTestPlan, duplicatedTestPlan);
     verify(tmsTestPlanTestCaseRepository).findTestCaseIdsByTestPlanId(testPlanId);
@@ -1115,7 +1116,7 @@ class TmsTestPlanServiceImplTest {
 
     when(testPlanRepository.findByIdAndProjectId(testPlanId, projectId))
         .thenReturn(Optional.of(originalTestPlan));
-    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan))
+    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan, (Long) null))
         .thenReturn(duplicatedTestPlan);
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
@@ -1126,13 +1127,13 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(expectedResponse);
 
     // When
-    var result = sut.duplicate(projectId, testPlanId);
+    var result = sut.duplicate(projectId, testPlanId, (Long) null);
 
     // Then
     assertNotNull(result);
     assertEquals(200L, result.getId());
     verify(testPlanRepository).findByIdAndProjectId(testPlanId, projectId);
-    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan);
+    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan, (Long) null);
     verify(testPlanRepository).save(duplicatedTestPlan);
     verify(tmsTestPlanAttributeService).duplicateTestPlanAttributes(originalTestPlan, duplicatedTestPlan);
     verify(tmsTestCaseService, never()).duplicateTestCases(anyLong(), anyList());
@@ -1147,12 +1148,12 @@ class TmsTestPlanServiceImplTest {
 
     // When/Then
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicate(projectId, testPlanId)
+        sut.duplicate(projectId, testPlanId, (Long) null)
     );
 
     assertEquals(ErrorType.NOT_FOUND, exception.getErrorType());
     verify(testPlanRepository).findByIdAndProjectId(testPlanId, projectId);
-    verify(tmsTestPlanMapper, never()).duplicateTestPlan(any(TmsTestPlan.class));
+    verify(tmsTestPlanMapper, never()).duplicateTestPlan(any(TmsTestPlan.class), nullable(Long.class));
     verify(testPlanRepository, never()).save(any());
   }
 
@@ -1631,7 +1632,8 @@ class TmsTestPlanServiceImplTest {
     // Setup for first duplicate call
     when(testPlanRepository.findByIdAndProjectId(testPlan1Id, projectId))
         .thenReturn(Optional.of(originalTestPlan1));
-    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan1))
+    Long targetMilestoneId = 999L;
+    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan1, targetMilestoneId))
         .thenReturn(duplicatedTestPlan1Entity);
     when(testPlanRepository.save(duplicatedTestPlan1Entity))
         .thenReturn(duplicatedTestPlan1Entity);
@@ -1645,7 +1647,7 @@ class TmsTestPlanServiceImplTest {
     // Setup for second duplicate call
     when(testPlanRepository.findByIdAndProjectId(testPlan2Id, projectId))
         .thenReturn(Optional.of(originalTestPlan2));
-    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan2))
+    when(tmsTestPlanMapper.duplicateTestPlan(originalTestPlan2, targetMilestoneId))
         .thenReturn(duplicatedTestPlan2Entity);
     when(testPlanRepository.save(duplicatedTestPlan2Entity))
         .thenReturn(duplicatedTestPlan2Entity);
@@ -1655,7 +1657,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(duplicatedPlan2);
 
     // When
-    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId);
+    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId, targetMilestoneId);
 
     // Then
     assertNotNull(result);
@@ -1666,8 +1668,8 @@ class TmsTestPlanServiceImplTest {
     verify(testPlanRepository).findIdsByProjectIdAndMilestoneId(projectId, milestoneId);
     verify(testPlanRepository).findByIdAndProjectId(testPlan1Id, projectId);
     verify(testPlanRepository).findByIdAndProjectId(testPlan2Id, projectId);
-    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan1);
-    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan2);
+    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan1, targetMilestoneId);
+    verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan2, targetMilestoneId);
   }
 
   @Test
@@ -1677,7 +1679,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(List.of());
 
     // When
-    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId);
+    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId, 999L);
 
     // Then
     assertNotNull(result);
@@ -1685,7 +1687,7 @@ class TmsTestPlanServiceImplTest {
 
     verify(testPlanRepository).findIdsByProjectIdAndMilestoneId(projectId, milestoneId);
     verify(testPlanRepository, never()).findByIdAndProjectId(anyLong(), anyLong());
-    verify(tmsTestPlanMapper, never()).duplicateTestPlan(any(TmsTestPlan.class));
+    verify(tmsTestPlanMapper, never()).duplicateTestPlan(any(TmsTestPlan.class), nullable(Long.class));
   }
 
   @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test plans can now be duplicated directly into a specified milestone.
  * Duplicating a milestone also copies its associated test plans and manual scenarios.

* **Bug Fixes**
  * Deleting an in-progress manual launch now interrupts it before removing related data.
  * Batch deletion applies the same interruption and cleanup behavior.

* **Tests**
  * Added coverage for milestone duplication and manual launch deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->