### PR TITLE
Fix EPMRPP-117956: Set testCaseHash and uniqueId for retry nested steps

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/tms/mapper/NestedStepItemBuilder.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/mapper/NestedStepItemBuilder.java
@@ -95,6 +95,8 @@ public class NestedStepItemBuilder {
     newStep.setRetryOf(null);
     newStep.setParentId(parentRetryItem.getItemId());
     newStep.setTestCaseId(parentRetryItem.getTestCaseId());
+    newStep.setTestCaseHash(parentRetryItem.getTestCaseHash());
+    newStep.setUniqueId(originalStep.getUniqueId());
   
     var results = new TestItemResults();
     results.setStatus(StatusEnum.TO_RUN);


### PR DESCRIPTION
## Summary
Fixes EPMRPP-117956: Clear Status fails with error for scenario-based Test Executions (missing testCaseHash on retry nested steps).

When the status is cleared, the backend attempts to create a new retry test item and its nested steps. The method `NestedStepItemBuilder.buildRetryNestedStepItem()` is responsible for building the retry nested steps. However, it failed to set the `testCaseHash` property on the new step. Since the `test_item.test_case_hash` column in the database is defined as `NOT NULL`, the insertion failed.

This PR updates `buildRetryNestedStepItem` to set the `testCaseHash` from the `parentRetryItem` and `uniqueId` from the `originalStep`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retry nested steps now retain the original step’s unique identifier.
  * Improved consistency when creating retry step items by preserving existing step metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->