### PR TITLE
EPMRPP-118469 || Exclude manual launches from InterruptBrokenLaunchesJob and notifications & trim project name

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/events/handler/launch/LaunchNotificationRunner.java
+++ b/src/main/java/com/epam/reportportal/base/core/events/handler/launch/LaunchNotificationRunner.java
@@ -268,6 +268,11 @@ public class LaunchNotificationRunner
   }
 
   private void sendNotificationEvent(LaunchFinishedEvent launchFinishedEvent) {
+    final Launch launch = getLaunchHandler.get(launchFinishedEvent.getId());
+    if (launch.getLaunchType().isManual()) {
+      return;
+    }
+
     final Project project = getProjectHandler.get(launchFinishedEvent.getProjectId());
 
     String launchLink = linkGenerator.generateLaunchLink(launchFinishedEvent.getBaseUrl(),

--- a/src/main/java/com/epam/reportportal/base/core/project/impl/OrganizationProjectHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/project/impl/OrganizationProjectHandlerImpl.java
@@ -37,6 +37,7 @@ import com.epam.reportportal.base.core.events.domain.ProjectCreatedEvent;
 import com.epam.reportportal.base.core.events.domain.ProjectDeletedEvent;
 import com.epam.reportportal.base.core.project.OrganizationProjectHandler;
 import com.epam.reportportal.base.core.remover.ContentRemover;
+import com.epam.reportportal.base.infrastructure.model.ValidationConstraints;
 import com.epam.reportportal.base.infrastructure.persistence.binary.AttachmentBinaryDataService;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Condition;
@@ -59,6 +60,7 @@ import com.epam.reportportal.base.infrastructure.persistence.entity.project.Proj
 import com.epam.reportportal.base.infrastructure.persistence.entity.project.ProjectProfile;
 import com.epam.reportportal.base.infrastructure.persistence.entity.project.ProjectUtils;
 import com.epam.reportportal.base.infrastructure.persistence.entity.user.UserRole;
+import com.epam.reportportal.base.infrastructure.rules.commons.validation.Suppliers;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import com.epam.reportportal.base.util.SlugifyUtils;
@@ -169,6 +171,10 @@ public class OrganizationProjectHandlerImpl implements OrganizationProjectHandle
   @Override
   public ProjectInfo createProject(Long orgId, ProjectBase projectBase) {
     projectBase.setName(projectBase.getName().trim());
+    expect(projectBase.getName().length(), (Integer length) -> length >= ValidationConstraints.MIN_NAME_LENGTH)
+        .verify(ErrorType.INCORRECT_REQUEST,
+            Suppliers.formattedSupplier("Project name '{}' is too short after trimming whitespaces",
+                projectBase.getName()));
 
     Organization organization = organizationRepositoryCustom.findById(orgId)
         .orElseThrow(() -> new ReportPortalException(ErrorType.ORGANIZATION_NOT_FOUND, orgId));

--- a/src/main/java/com/epam/reportportal/base/core/project/impl/OrganizationProjectHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/project/impl/OrganizationProjectHandlerImpl.java
@@ -168,6 +168,8 @@ public class OrganizationProjectHandlerImpl implements OrganizationProjectHandle
 
   @Override
   public ProjectInfo createProject(Long orgId, ProjectBase projectBase) {
+    projectBase.setName(projectBase.getName().trim());
+
     Organization organization = organizationRepositoryCustom.findById(orgId)
         .orElseThrow(() -> new ReportPortalException(ErrorType.ORGANIZATION_NOT_FOUND, orgId));
 

--- a/src/main/java/com/epam/reportportal/base/core/project/patch/PatchProjectNameHandler.java
+++ b/src/main/java/com/epam/reportportal/base/core/project/patch/PatchProjectNameHandler.java
@@ -19,6 +19,7 @@ package com.epam.reportportal.base.core.project.patch;
 import com.epam.reportportal.api.model.PatchOperation;
 import com.epam.reportportal.base.core.project.ProjectService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 /**
@@ -54,7 +55,7 @@ public class PatchProjectNameHandler extends BasePatchProjectHandler {
    */
   @Override
   public void replace(PatchOperation operation, Long orgId, Long projectId) {
-    projectService.updateProjectName(orgId, projectId, (String) operation.getValue());
+    projectService.updateProjectName(orgId, projectId, StringUtils.trim((String) operation.getValue()));
   }
 
 }

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/LaunchRepository.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/LaunchRepository.java
@@ -109,6 +109,16 @@ public interface LaunchRepository extends ReportPortalRepository<Launch, Long>,
   Stream<Long> streamIdsByStartTimeBefore(@Param("projectId") Long projectId,
       @Param("before") Instant before);
 
+  /**
+   * Streams launch IDs filtered by status, project, and start-time cutoff, excluding launches of the specified launch
+   * type.
+   *
+   * @param projectId          the project to filter launches by
+   * @param status             the launch status to filter by
+   * @param before             the start-time cutoff; only launches started before this instant are included
+   * @param excludedLaunchType the launch type to exclude from the results
+   * @return a stream of matching launch IDs
+   */
   @QueryHints(@QueryHint(name = HINT_FETCH_SIZE, value = "1"))
   @Query("""
       SELECT l.id

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/LaunchRepository.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/LaunchRepository.java
@@ -109,11 +109,21 @@ public interface LaunchRepository extends ReportPortalRepository<Launch, Long>,
   Stream<Long> streamIdsByStartTimeBefore(@Param("projectId") Long projectId,
       @Param("before") Instant before);
 
-  @QueryHints(value = @QueryHint(name = HINT_FETCH_SIZE, value = "1"))
-  @Query(value = "SELECT l.id FROM Launch l WHERE l.status = :status AND l.projectId = :projectId AND l.startTime < :before")
-  Stream<Long> streamIdsWithStatusAndStartTimeBefore(@Param("projectId") Long projectId,
+  @QueryHints(@QueryHint(name = HINT_FETCH_SIZE, value = "1"))
+  @Query("""
+      SELECT l.id
+      FROM Launch l
+      WHERE l.status = :status
+        AND l.projectId = :projectId
+        AND l.startTime < :before
+        AND l.launchType <> :excludedLaunchType
+      """)
+  Stream<Long> streamIdsWithStatusAndStartTimeBefore(
+      @Param("projectId") Long projectId,
       @Param("status") StatusEnum status,
-      @Param("before") Instant before);
+      @Param("before") Instant before,
+      @Param("excludedLaunchType") LaunchTypeEnum excludedLaunchType
+  );
 
   @Query(value = "SELECT * FROM launch l WHERE l.id <= :startingLaunchId AND l.name = :launchName "
       + "AND l.project_id = :projectId AND l.mode <> 'DEBUG' ORDER BY start_time DESC, number DESC LIMIT :historyDepth", nativeQuery = true)

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/enums/LaunchTypeEnum.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/enums/LaunchTypeEnum.java
@@ -2,10 +2,12 @@ package com.epam.reportportal.base.infrastructure.persistence.entity.enums;
 
 import java.util.Arrays;
 import java.util.Optional;
+import lombok.Getter;
 
 /**
  * Launch type enum.
  */
+@Getter
 public enum LaunchTypeEnum {
 
   AUTOMATION("AUTOMATION"),
@@ -16,10 +18,6 @@ public enum LaunchTypeEnum {
 
   LaunchTypeEnum(String value) {
     this.value = value;
-  }
-
-  public String getValue() {
-    return value;
   }
 
   public static Optional<LaunchTypeEnum> fromValue(String value) {

--- a/src/main/java/com/epam/reportportal/base/job/InterruptBrokenLaunchesJob.java
+++ b/src/main/java/com/epam/reportportal/base/job/InterruptBrokenLaunchesJob.java
@@ -27,6 +27,7 @@ import com.epam.reportportal.base.infrastructure.persistence.dao.LaunchRepositor
 import com.epam.reportportal.base.infrastructure.persistence.dao.LogRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.TestItemRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.enums.LaunchTypeEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.ProjectAttributeEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.StatusEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.launch.Launch;
@@ -47,7 +48,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Finds jobs witn duration more than defined and finishes them with interrupted {@link StatusEnum#INTERRUPTED} status
+ * Finds jobs with duration more than defined and finishes them with interrupted {@link StatusEnum#INTERRUPTED} status
  *
  * @author Andrei Varabyeu
  */
@@ -85,7 +86,8 @@ public class InterruptBrokenLaunchesJob implements Job {
                 try (Stream<Long> ids = launchRepository.streamIdsWithStatusAndStartTimeBefore(
                     project.getId(),
                     StatusEnum.IN_PROGRESS,
-                    Instant.now().minus(maxDuration.toSeconds(), ChronoUnit.SECONDS)
+                    Instant.now().minus(maxDuration.toSeconds(), ChronoUnit.SECONDS),
+                    LaunchTypeEnum.MANUAL
                 )) {
                   ids.forEach(launchId -> {
                     if (!testItemRepository.hasItemsInStatusByLaunch(launchId,

--- a/src/test/java/com/epam/reportportal/base/core/events/handler/launch/LaunchNotificationRunnerTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/events/handler/launch/LaunchNotificationRunnerTest.java
@@ -20,6 +20,7 @@ import static com.epam.reportportal.base.ReportPortalUserUtil.getRpUser;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,6 +35,7 @@ import com.epam.reportportal.base.core.project.GetProjectHandler;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.dao.UserRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.LaunchModeEnum;
+import com.epam.reportportal.base.infrastructure.persistence.entity.enums.LaunchTypeEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.ReservedIntegrationTypeEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.ProjectAttributeEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.StatusEnum;
@@ -45,6 +47,7 @@ import com.epam.reportportal.base.infrastructure.persistence.entity.project.Proj
 import com.epam.reportportal.base.infrastructure.persistence.entity.user.UserRole;
 import com.epam.reportportal.base.util.email.EmailService;
 import com.epam.reportportal.base.util.email.MailServiceFactory;
+import com.epam.reportportal.extension.event.LaunchFinishedNotificationEvent;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
@@ -176,6 +179,27 @@ class LaunchNotificationRunnerTest {
         eq(event.getProjectId()), eq(event.getOrganizationId()), eq(ReservedIntegrationTypeEnum.EMAIL.getName()));
     verify(mailServiceFactory).getDefaultEmailService(emailIntegration);
     verify(emailService, times(2)).sendLaunchFinishNotification(any(), any(), any(), any());
+  }
+
+  @Test
+  void shouldNotSendChatNotificationForManualLaunch() {
+    final Launch launch = LaunchTestUtil.getLaunch(StatusEnum.FAILED, LaunchModeEnum.DEFAULT).get();
+    launch.setName("name1");
+    launch.setLaunchType(LaunchTypeEnum.MANUAL);
+    final ReportPortalUser user = getRpUser("user", UserRole.USER, OrganizationRole.MEMBER,
+        ProjectRole.VIEWER,
+        launch.getProjectId());
+    final LaunchFinishedEvent event = new LaunchFinishedEvent(launch, user, "baseUrl", 1L, "helen");
+
+    final Map<String, String> mapping = ImmutableMap.<String, String>builder()
+        .put(ProjectAttributeEnum.NOTIFICATIONS_ENABLED.getAttribute(), "true")
+        .build();
+
+    when(getLaunchHandler.get(event.getId())).thenReturn(launch);
+
+    runner.handle(event, mapping);
+
+    verify(eventPublisher, never()).publishEvent(any(LaunchFinishedNotificationEvent.class));
   }
 
 }

--- a/src/test/java/com/epam/reportportal/base/infrastructure/persistence/dao/LaunchRepositoryTest.java
+++ b/src/test/java/com/epam/reportportal/base/infrastructure/persistence/dao/LaunchRepositoryTest.java
@@ -39,6 +39,7 @@ import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Co
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Filter;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.FilterCondition;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.LaunchModeEnum;
+import com.epam.reportportal.base.infrastructure.persistence.entity.enums.LaunchTypeEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.RetentionPolicyEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.StatusEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.launch.Launch;
@@ -148,7 +149,8 @@ class LaunchRepositoryTest extends BaseMvcTest {
 
     Stream<Long> stream = launchRepository.streamIdsWithStatusAndStartTimeBefore(1L,
         StatusEnum.IN_PROGRESS,
-        Instant.now().minusSeconds(Duration.ofDays(13).getSeconds())
+        Instant.now().minusSeconds(Duration.ofDays(13).getSeconds()),
+        LaunchTypeEnum.MANUAL
     );
 
     assertNotNull(stream);

--- a/src/test/java/com/epam/reportportal/base/job/InterruptBrokenLaunchesJobTest.java
+++ b/src/test/java/com/epam/reportportal/base/job/InterruptBrokenLaunchesJobTest.java
@@ -17,6 +17,7 @@
 package com.epam.reportportal.base.job;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,6 +29,7 @@ import com.epam.reportportal.base.infrastructure.persistence.dao.LogRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.TestItemRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.attribute.Attribute;
+import com.epam.reportportal.base.infrastructure.persistence.entity.enums.LaunchTypeEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.StatusEnum;
 import com.epam.reportportal.base.infrastructure.persistence.entity.launch.Launch;
 import com.epam.reportportal.base.infrastructure.persistence.entity.project.Project;
@@ -89,7 +91,7 @@ class InterruptBrokenLaunchesJobTest {
 
     when(projectRepository.findAllIdsAndProjectAttributes(any())).thenReturn(
         new PageImpl<>(Collections.singletonList(project)));
-    when(launchRepository.streamIdsWithStatusAndStartTimeBefore(any(), any(), any())).thenReturn(
+    when(launchRepository.streamIdsWithStatusAndStartTimeBefore(any(), any(), any(), any())).thenReturn(
         Stream.of(launchId));
     when(testItemRepository.hasItemsInStatusByLaunch(launchId, StatusEnum.IN_PROGRESS)).thenReturn(
         false);
@@ -120,7 +122,7 @@ class InterruptBrokenLaunchesJobTest {
 
     when(projectRepository.findAllIdsAndProjectAttributes(any())).thenReturn(
         new PageImpl<>(Collections.singletonList(project)));
-    when(launchRepository.streamIdsWithStatusAndStartTimeBefore(any(), any(), any())).thenReturn(
+    when(launchRepository.streamIdsWithStatusAndStartTimeBefore(any(), any(), any(), any())).thenReturn(
         Stream.of(launchId));
     when(testItemRepository.hasItemsInStatusByLaunch(launchId, StatusEnum.IN_PROGRESS)).thenReturn(
         true);
@@ -138,5 +140,26 @@ class InterruptBrokenLaunchesJobTest {
     verify(launchRepository, times(1)).findById(launchId);
     verify(launchRepository, times(1)).save(any());
 
+  }
+
+  @Test
+  void shouldExcludeManualLaunchesFromInterruptQuery() {
+    Project project = new Project();
+    final ProjectAttribute projectAttribute = new ProjectAttribute();
+    final Attribute attribute = new Attribute();
+    attribute.setName("job.interruptJobTime");
+    projectAttribute.setAttribute(attribute);
+    projectAttribute.setValue(String.valueOf(3600 * 24));
+    project.setProjectAttributes(Sets.newHashSet(projectAttribute));
+
+    when(projectRepository.findAllIdsAndProjectAttributes(any())).thenReturn(
+        new PageImpl<>(Collections.singletonList(project)));
+    when(launchRepository.streamIdsWithStatusAndStartTimeBefore(any(), any(), any(),
+        eq(LaunchTypeEnum.MANUAL))).thenReturn(Stream.empty());
+
+    interruptBrokenLaunchesJob.execute(null);
+
+    verify(launchRepository).streamIdsWithStatusAndStartTimeBefore(any(), eq(StatusEnum.IN_PROGRESS),
+        any(), eq(LaunchTypeEnum.MANUAL));
   }
 }

--- a/src/test/java/com/epam/reportportal/base/job/InterruptBrokenLaunchesJobTest.java
+++ b/src/test/java/com/epam/reportportal/base/job/InterruptBrokenLaunchesJobTest.java
@@ -144,7 +144,7 @@ class InterruptBrokenLaunchesJobTest {
 
   @Test
   void shouldExcludeManualLaunchesFromInterruptQuery() {
-    Project project = new Project();
+    final Project project = new Project();
     final ProjectAttribute projectAttribute = new ProjectAttribute();
     final Attribute attribute = new Attribute();
     attribute.setName("job.interruptJobTime");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manual launches no longer generate completion notifications.
  * Automatic launch processing remains unchanged.
  * Broken-launch recovery now targets only manual launches.
  * Project names are trimmed automatically when creating or editing projects.
  * Launch filtering now excludes specified launch types more accurately.

* **Tests**
  * Added coverage for manual launch notifications and interruption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->