### PR TITLE
EPMRPP-117831 || Filter out manual launches from widgets

### DIFF
--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/WidgetContentRepositoryImpl.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/dao/WidgetContentRepositoryImpl.java
@@ -726,7 +726,10 @@ public class WidgetContentRepositoryImpl implements WidgetContentRepository {
         .filter(cf -> cf.contains(DEFECTS_KEY)).collect(toList());
 
     return LAUNCHES_STATISTICS_FETCHER.apply(dsl.with(LAUNCHES)
-        .as(QueryBuilder.newBuilder(filter, collectJoinFields(filter, sort)).with(sort).with(limit)
+        .as(QueryBuilder.newBuilder(filter, collectJoinFields(filter, sort))
+            .addCondition(LAUNCH.LAUNCH_TYPE.notEqual(JLaunchTypeEnum.MANUAL))
+            .with(sort)
+            .with(limit)
             .build())
         .select(LAUNCH.ID,
             LAUNCH.NAME,
@@ -1086,6 +1089,7 @@ public class WidgetContentRepositoryImpl implements WidgetContentRepository {
 
     Table<? extends Record> launchesTable = QueryUtils.createQueryBuilderWithLatestLaunchesOption(
             launchFilter, launchSort, isLatest)
+        .addCondition(LAUNCH.LAUNCH_TYPE.notEqual(JLaunchTypeEnum.MANUAL))
         .with(launchesLimit)
         .with(launchSort)
         .build()
@@ -1172,6 +1176,7 @@ public class WidgetContentRepositoryImpl implements WidgetContentRepository {
             FIRST_LEVEL)
         .as(dsl.with(LAUNCHES)
             .as(QueryBuilder.newBuilder(launchFilter, collectJoinFields(launchFilter))
+                .addCondition(LAUNCH.LAUNCH_TYPE.notEqual(JLaunchTypeEnum.MANUAL))
                 .with(launchesSort)
                 .with(launchesLimit)
                 .build())
@@ -1329,6 +1334,7 @@ public class WidgetContentRepositoryImpl implements WidgetContentRepository {
 
     Table<? extends Record> launchesTable = QueryUtils.createQueryBuilderWithLatestLaunchesOption(
             launchFilter, launchSort, isLatest)
+        .addCondition(LAUNCH.LAUNCH_TYPE.notEqual(JLaunchTypeEnum.MANUAL))
         .with(launchesLimit)
         .with(launchSort)
         .build()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Widget reports now exclude manually created launches from comparison statistics, component health checks, cumulative trend charts, and component health check tables.
  * Updated visualizations and health metrics provide more accurate automated launch data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->