### PR TITLE
Fix: Include execution comment attachments in TMS attachment cleanup job

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImpl.java
@@ -6,6 +6,7 @@ import com.epam.reportportal.base.infrastructure.persistence.binary.tms.TmsAttac
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsAttachmentRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsManualScenarioPreconditionsAttachmentRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsStepAttachmentRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestCaseExecutionCommentAttachmentRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTextManualScenarioAttachmentRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsAttachment;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
@@ -40,6 +41,7 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
   private final TmsStepAttachmentRepository tmsStepAttachmentRepository;
   private final TmsTextManualScenarioAttachmentRepository tmsTextManualScenarioAttachmentRepository;
   private final TmsManualScenarioPreconditionsAttachmentRepository tmsManualScenarioPreconditionsAttachmentRepository;
+  private final TmsTestCaseExecutionCommentAttachmentRepository tmsTestCaseExecutionCommentAttachmentRepository;
 
   @Value("${rp.tms.attachment.ttl:PT24H}")
   private Duration ttl;
@@ -288,6 +290,12 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
     var preconditionsAttachmentIds = tmsManualScenarioPreconditionsAttachmentRepository.findAllAttachmentIds();
     usedIds.addAll(preconditionsAttachmentIds);
     log.debug("Found {} attachment IDs in preconditions attachments", preconditionsAttachmentIds.size());
+
+    // Get attachment IDs from test case execution comment attachments
+    var testCaseExecutionCommentAttachmentIds = tmsTestCaseExecutionCommentAttachmentRepository.findAllAttachmentIds();
+    usedIds.addAll(testCaseExecutionCommentAttachmentIds);
+    log.debug("Found {} attachment IDs in test case execution comment attachments",
+        testCaseExecutionCommentAttachmentIds.size());
 
     log.debug("Total unique attachment IDs in use: {}", usedIds.size());
     return usedIds;

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImplTest.java
@@ -16,14 +16,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.epam.reportportal.base.core.tms.dto.UploadAttachmentRS;
+import com.epam.reportportal.base.core.tms.mapper.TmsAttachmentMapper;
 import com.epam.reportportal.base.infrastructure.persistence.binary.tms.TmsAttachmentDataStoreService;
-import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsAttachment;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsAttachmentRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsManualScenarioPreconditionsAttachmentRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsStepAttachmentRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestCaseExecutionCommentAttachmentRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTextManualScenarioAttachmentRepository;
-import com.epam.reportportal.base.core.tms.dto.UploadAttachmentRS;
-import com.epam.reportportal.base.core.tms.mapper.TmsAttachmentMapper;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsAttachment;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import java.io.ByteArrayInputStream;
@@ -66,6 +67,9 @@ class TmsAttachmentServiceImplTest {
   @Mock
   private TmsManualScenarioPreconditionsAttachmentRepository tmsManualScenarioPreconditionsAttachmentRepository;
 
+  @Mock
+  private TmsTestCaseExecutionCommentAttachmentRepository tmsTestCaseExecutionCommentAttachmentRepository;
+
   @InjectMocks
   private TmsAttachmentServiceImpl sut;
 
@@ -105,8 +109,10 @@ class TmsAttachmentServiceImplTest {
   @Test
   void uploadAttachment_ShouldSucceed_WhenValidFile() throws Exception {
     // Given valid file to upload
-    when(tmsAttachmentDataStoreService.save(anyString(), any(InputStream.class))).thenReturn(fileId);
-    when(tmsAttachmentMapper.convertToAttachment(eq(fileId), any(), eq(file))).thenReturn(attachment);
+    when(tmsAttachmentDataStoreService.save(anyString(), any(InputStream.class))).thenReturn(
+        fileId);
+    when(tmsAttachmentMapper.convertToAttachment(eq(fileId), any(), eq(file))).thenReturn(
+        attachment);
     when(tmsAttachmentRepository.save(attachment)).thenReturn(attachment);
     when(tmsAttachmentMapper.convertToUploadAttachmentRS(attachment)).thenReturn(
         uploadAttachmentRS);
@@ -135,9 +141,12 @@ class TmsAttachmentServiceImplTest {
         () -> sut.uploadAttachment(emptyFile));
 
     assertEquals(ErrorType.BAD_REQUEST_ERROR, exception.getErrorType());
-    assertEquals("Error in handled Request. Please, check specified parameters: 'File cannot be empty'", exception.getMessage());
+    assertEquals(
+        "Error in handled Request. Please, check specified parameters: 'File cannot be empty'",
+        exception.getMessage());
 
-    verifyNoInteractions(tmsAttachmentDataStoreService, tmsAttachmentMapper, tmsAttachmentRepository);
+    verifyNoInteractions(tmsAttachmentDataStoreService, tmsAttachmentMapper,
+        tmsAttachmentRepository);
   }
 
   @Test
@@ -221,7 +230,8 @@ class TmsAttachmentServiceImplTest {
   void deleteAttachment_ShouldThrowException_WhenDataStoreDeleteFails() {
     // Given attachment exists but data store delete operation fails
     when(tmsAttachmentRepository.findById(attachmentId)).thenReturn(Optional.of(attachment));
-    doThrow(new RuntimeException("Delete failed")).when(tmsAttachmentDataStoreService).delete(fileId);
+    doThrow(new RuntimeException("Delete failed")).when(tmsAttachmentDataStoreService)
+        .delete(fileId);
 
     // When/Then exception should be thrown when data store delete fails
     var exception = assertThrows(ReportPortalException.class,
@@ -405,7 +415,8 @@ class TmsAttachmentServiceImplTest {
   @Test
   void duplicateTmsAttachment_ShouldThrowException_WhenOriginalFileNotFound() {
     // Given original file does not exist in data store
-    when(tmsAttachmentDataStoreService.load(attachment.getPathToFile())).thenReturn(Optional.empty());
+    when(tmsAttachmentDataStoreService.load(attachment.getPathToFile())).thenReturn(
+        Optional.empty());
 
     // When/Then exception should be thrown when original file is not found
     var exception = assertThrows(ReportPortalException.class,
@@ -454,6 +465,8 @@ class TmsAttachmentServiceImplTest {
         Collections.emptyList());
     when(tmsManualScenarioPreconditionsAttachmentRepository.findAllAttachmentIds()).thenReturn(
         Collections.emptyList());
+    when(tmsTestCaseExecutionCommentAttachmentRepository.findAllAttachmentIds()).thenReturn(
+        Collections.emptyList());
     when(tmsAttachmentRepository.setExpirationForAttachments(anyList(),
         any(Instant.class))).thenReturn(2);
 
@@ -465,6 +478,7 @@ class TmsAttachmentServiceImplTest {
     verify(tmsStepAttachmentRepository).findAllAttachmentIds();
     verify(tmsTextManualScenarioAttachmentRepository).findAllAttachmentIds();
     verify(tmsManualScenarioPreconditionsAttachmentRepository).findAllAttachmentIds();
+    verify(tmsTestCaseExecutionCommentAttachmentRepository).findAllAttachmentIds();
 
     var idsCaptor = ArgumentCaptor.forClass(List.class);
     var instantCaptor = ArgumentCaptor.forClass(Instant.class);
@@ -493,6 +507,7 @@ class TmsAttachmentServiceImplTest {
     verifyNoInteractions(tmsStepAttachmentRepository);
     verifyNoInteractions(tmsTextManualScenarioAttachmentRepository);
     verifyNoInteractions(tmsManualScenarioPreconditionsAttachmentRepository);
+    verifyNoInteractions(tmsTestCaseExecutionCommentAttachmentRepository);
     verify(tmsAttachmentRepository, never()).setExpirationForAttachments(anyList(),
         any(Instant.class));
   }
@@ -514,6 +529,8 @@ class TmsAttachmentServiceImplTest {
         Collections.emptyList());
     when(tmsManualScenarioPreconditionsAttachmentRepository.findAllAttachmentIds()).thenReturn(
         Collections.emptyList());
+    when(tmsTestCaseExecutionCommentAttachmentRepository.findAllAttachmentIds()).thenReturn(
+        Collections.emptyList());
 
     // When setting expiration for unused attachments
     sut.setExpirationForUnusedAttachments();
@@ -523,6 +540,7 @@ class TmsAttachmentServiceImplTest {
     verify(tmsStepAttachmentRepository).findAllAttachmentIds();
     verify(tmsTextManualScenarioAttachmentRepository).findAllAttachmentIds();
     verify(tmsManualScenarioPreconditionsAttachmentRepository).findAllAttachmentIds();
+    verify(tmsTestCaseExecutionCommentAttachmentRepository).findAllAttachmentIds();
     verify(tmsAttachmentRepository, never()).setExpirationForAttachments(anyList(),
         any(Instant.class));
   }
@@ -547,6 +565,8 @@ class TmsAttachmentServiceImplTest {
         List.of(2L));
     when(tmsManualScenarioPreconditionsAttachmentRepository.findAllAttachmentIds()).thenReturn(
         Collections.emptyList());
+    when(tmsTestCaseExecutionCommentAttachmentRepository.findAllAttachmentIds()).thenReturn(
+        Collections.emptyList());
     when(tmsAttachmentRepository.setExpirationForAttachments(anyList(),
         any(Instant.class))).thenReturn(1);
 
@@ -554,6 +574,11 @@ class TmsAttachmentServiceImplTest {
     sut.setExpirationForUnusedAttachments();
 
     // Then expiration should be set only for genuinely unused attachment
+    verify(tmsStepAttachmentRepository).findAllAttachmentIds();
+    verify(tmsTextManualScenarioAttachmentRepository).findAllAttachmentIds();
+    verify(tmsManualScenarioPreconditionsAttachmentRepository).findAllAttachmentIds();
+    verify(tmsTestCaseExecutionCommentAttachmentRepository).findAllAttachmentIds();
+
     var idsCaptor = ArgumentCaptor.forClass(List.class);
     verify(tmsAttachmentRepository).setExpirationForAttachments(idsCaptor.capture(),
         any(Instant.class));
@@ -582,6 +607,8 @@ class TmsAttachmentServiceImplTest {
         List.of(1L)); // Same ID in multiple tables
     when(tmsManualScenarioPreconditionsAttachmentRepository.findAllAttachmentIds()).thenReturn(
         Collections.emptyList());
+    when(tmsTestCaseExecutionCommentAttachmentRepository.findAllAttachmentIds()).thenReturn(
+        Collections.emptyList());
     when(tmsAttachmentRepository.setExpirationForAttachments(anyList(),
         any(Instant.class))).thenReturn(1);
 
@@ -589,6 +616,11 @@ class TmsAttachmentServiceImplTest {
     sut.setExpirationForUnusedAttachments();
 
     // Then expiration should be set only for attachment not used in any table
+    verify(tmsStepAttachmentRepository).findAllAttachmentIds();
+    verify(tmsTextManualScenarioAttachmentRepository).findAllAttachmentIds();
+    verify(tmsManualScenarioPreconditionsAttachmentRepository).findAllAttachmentIds();
+    verify(tmsTestCaseExecutionCommentAttachmentRepository).findAllAttachmentIds();
+
     var idsCaptor = ArgumentCaptor.forClass(List.class);
     verify(tmsAttachmentRepository).setExpirationForAttachments(idsCaptor.capture(),
         any(Instant.class));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachments referenced in test case execution comments are now correctly recognized as in use.
  * Prevents these attachments from being incorrectly marked for expiration by retention policies.
* **Tests**
  * Added coverage for empty, overlapping, mixed-use, and no-attachment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->