### PR TITLE
EPMRPP-117065 || Refactor account type validation

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/user/UserMutationService.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/UserMutationService.java
@@ -60,12 +60,13 @@ public interface UserMutationService {
   void updateActive(User user, Object value);
 
   /**
-   * Updates user account type (INTERNAL or SCIM only).
+   * Updates user account type.
    *
-   * @param user        the user entity to update
-   * @param accountType the new account type as string
+   * @param user                 the user entity to update
+   * @param accountType          the new account type as string
+   * @param restrictAllowedTypes when {@code true}, only INTERNAL or SCIM are allowed
    */
-  void updateAccountType(User user, String accountType);
+  void updateAccountType(User user, String accountType, boolean restrictAllowedTypes);
 
   /**
    * Updates user external ID with duplicate checking.

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/EditUserHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/EditUserHandlerImpl.java
@@ -224,7 +224,7 @@ public class EditUserHandlerImpl implements EditUserHandler {
     });
     ofNullable(editUserRq.getAccountType()).ifPresent(accountType -> {
       checkPossibilityToEdit(editor, user, "accountType");
-      userMutationService.updateAccountType(user, accountType);
+      userMutationService.updateAccountType(user, accountType, true);
     });
   }
 

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImpl.java
@@ -125,7 +125,7 @@ public class UserMutationServiceImpl implements UserMutationService {
   }
 
   @Override
-  public void updateAccountType(User user, String accountType) {
+  public void updateAccountType(User user, String accountType, boolean restrictAllowedTypes) {
     expect(StringUtils.isNotBlank(accountType), Boolean.TRUE::equals)
         .verify(BAD_REQUEST_ERROR, "Account type must not be empty.");
 
@@ -133,8 +133,10 @@ public class UserMutationServiceImpl implements UserMutationService {
         .orElseThrow(() -> new ReportPortalException(BAD_REQUEST_ERROR,
             "Incorrect specified Account Type parameter."));
 
-    expect(ALLOWED_ACCOUNT_TYPES.contains(type), Boolean.TRUE::equals)
-        .verify(BAD_REQUEST_ERROR, "Account type can only be set to INTERNAL or SCIM.");
+    if (restrictAllowedTypes) {
+      expect(ALLOWED_ACCOUNT_TYPES.contains(type), Boolean.TRUE::equals)
+          .verify(BAD_REQUEST_ERROR, "Account type can only be set to INTERNAL or SCIM.");
+    }
 
     user.setUserType(type);
   }

--- a/src/main/java/com/epam/reportportal/base/core/user/patch/PatchUserHandler.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/patch/PatchUserHandler.java
@@ -150,7 +150,8 @@ public class PatchUserHandler {
           case ACTIVE_PATH ->
               userMutationService.updateActive(user, validateAndGetTypedValue(operation, path, Boolean.class));
           case ACCOUNT_TYPE_PATH ->
-              userMutationService.updateAccountType(user, validateAndGetTypedValue(operation, path, String.class));
+              userMutationService.updateAccountType(user, validateAndGetTypedValue(operation, path, String.class),
+                  false);
           case EXTERNAL_ID_PATH ->
               userMutationService.updateExternalId(user, validateAndGetTypedValue(operation, path, String.class));
           case null, default -> throw new IllegalArgumentException(UNEXPECTED_PATH_MESSAGE.formatted(path));

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImplTest.java
@@ -294,7 +294,7 @@ class UserMutationServiceImplTest {
     @Test
     @DisplayName("Should reject blank account type")
     void updateAccountTypeWhenBlankShouldThrow() {
-      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "  "))
+      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "  ", true))
           .isInstanceOf(ReportPortalException.class)
           .hasMessageContaining("must not be empty");
     }
@@ -302,39 +302,39 @@ class UserMutationServiceImplTest {
     @Test
     @DisplayName("Should reject null account type")
     void updateAccountTypeWhenNullShouldThrow() {
-      assertThatThrownBy(() -> userMutationService.updateAccountType(user, null))
+      assertThatThrownBy(() -> userMutationService.updateAccountType(user, null, true))
           .isInstanceOf(ReportPortalException.class)
           .hasMessageContaining("must not be empty");
     }
 
     @Test
-    @DisplayName("Should reject UPSA account type")
+    @DisplayName("Should reject UPSA account type when restricted")
     void updateAccountTypeWhenUpsaShouldThrow() {
-      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "UPSA"))
+      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "UPSA", true))
           .isInstanceOf(ReportPortalException.class)
           .hasMessageContaining("can only be set to INTERNAL or SCIM");
     }
 
     @Test
-    @DisplayName("Should reject LDAP account type")
+    @DisplayName("Should reject LDAP account type when restricted")
     void updateAccountTypeWhenLdapShouldThrow() {
-      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "LDAP"))
+      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "LDAP", true))
           .isInstanceOf(ReportPortalException.class)
           .hasMessageContaining("can only be set to INTERNAL or SCIM");
     }
 
     @Test
-    @DisplayName("Should reject SAML account type")
+    @DisplayName("Should reject SAML account type when restricted")
     void updateAccountTypeWhenSamlShouldThrow() {
-      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "SAML"))
+      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "SAML", true))
           .isInstanceOf(ReportPortalException.class)
           .hasMessageContaining("can only be set to INTERNAL or SCIM");
     }
 
     @Test
-    @DisplayName("Should reject GITHUB account type")
+    @DisplayName("Should reject GITHUB account type when restricted")
     void updateAccountTypeWhenGithubShouldThrow() {
-      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "GITHUB"))
+      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "GITHUB", true))
           .isInstanceOf(ReportPortalException.class)
           .hasMessageContaining("can only be set to INTERNAL or SCIM");
     }
@@ -342,7 +342,7 @@ class UserMutationServiceImplTest {
     @Test
     @DisplayName("Should reject invalid account type")
     void updateAccountTypeWhenInvalidShouldThrow() {
-      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "UNKNOWN"))
+      assertThatThrownBy(() -> userMutationService.updateAccountType(user, "UNKNOWN", true))
           .isInstanceOf(ReportPortalException.class)
           .hasMessageContaining("Incorrect specified Account Type");
     }
@@ -350,7 +350,7 @@ class UserMutationServiceImplTest {
     @Test
     @DisplayName("Should accept INTERNAL account type")
     void updateAccountTypeWhenInternalShouldUpdate() {
-      userMutationService.updateAccountType(user, "INTERNAL");
+      userMutationService.updateAccountType(user, "INTERNAL", true);
 
       assertThat(user.getUserType()).isEqualTo(UserType.INTERNAL);
     }
@@ -358,9 +358,17 @@ class UserMutationServiceImplTest {
     @Test
     @DisplayName("Should accept SCIM account type")
     void updateAccountTypeWhenScimShouldUpdate() {
-      userMutationService.updateAccountType(user, "SCIM");
+      userMutationService.updateAccountType(user, "SCIM", true);
 
       assertThat(user.getUserType()).isEqualTo(UserType.SCIM);
+    }
+
+    @Test
+    @DisplayName("Should accept GITHUB account type when unrestricted")
+    void updateAccountTypeWhenGithubAndUnrestrictedShouldUpdate() {
+      userMutationService.updateAccountType(user, "GITHUB", false);
+
+      assertThat(user.getUserType()).isEqualTo(UserType.GITHUB);
     }
   }
 

--- a/src/test/java/com/epam/reportportal/base/core/user/patch/PatchUserHandlerTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/patch/PatchUserHandlerTest.java
@@ -461,7 +461,7 @@ class PatchUserHandlerTest {
     op.setValue("INTERNAL");
     patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op));
 
-    verify(userMutationService).updateAccountType(targetUser, "INTERNAL");
+    verify(userMutationService).updateAccountType(targetUser, "INTERNAL", false);
   }
 
   @Test
@@ -476,6 +476,6 @@ class PatchUserHandlerTest {
     op.setValue("SCIM");
     patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op));
 
-    verify(userMutationService).updateAccountType(targetUser, "SCIM");
+    verify(userMutationService).updateAccountType(targetUser, "SCIM", false);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account type updates can now support additional external account types when unrestricted.
  * Restricted account updates continue to allow only `INTERNAL` and `SCIM` types.
* **Bug Fixes**
  * Account type values are consistently validated, including invalid, blank, and null inputs.
  * Existing restrictions for UPSA, LDAP, SAML, and GITHUB account types remain enforced where required.
* **Tests**
  * Added coverage confirming GITHUB is accepted for unrestricted account updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->