### PR TITLE
EPMRPP-118370 || Enforce restrictions on admin self-updates

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/user/patch/PatchUserHandler.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/patch/PatchUserHandler.java
@@ -40,7 +40,9 @@ import org.springframework.util.Assert;
  * <p>Authorization rules:
  * <ul>
  *   <li>Administrators may update email, full_name, role, active, account_type and external_id of
- *       any user.</li>
+ *       any other user.</li>
+ *   <li>Administrators may not change their own account_type, external_id, active or
+ *       instance_role (only email and full_name).</li>
  *   <li>Regular users may update only their own email and full name.</li>
  * </ul>
  *
@@ -59,6 +61,8 @@ public class PatchUserHandler {
   public static final String EXTERNAL_ID_PATH = "/external_id";
   private static final String UNEXPECTED_PATH_MESSAGE = "Unexpected path: '%s'";
   private static final Set<String> ALLOWED_SELF_UPDATE_PATHS = Set.of(EMAIL_PATH, FULL_NAME_PATH);
+  private static final Set<String> ADMIN_SELF_RESTRICTED_PATHS =
+      Set.of(ACCOUNT_TYPE_PATH, EXTERNAL_ID_PATH, ACTIVE_PATH, ROLE_PATH);
 
   private final UserService userService;
   private final UserMutationService userMutationService;
@@ -90,12 +94,12 @@ public class PatchUserHandler {
    *
    * <p>Authorization rules enforced:
    * <ul>
-   *   <li>Administrators can update any field for any user</li>
+   *   <li>Administrators can update any field for any other user</li>
+   *   <li>Administrators cannot update their own account_type, external_id, active or
+   *       instance_role</li>
    *   <li>Regular users can only update their own profile</li>
    *   <li>Regular users are restricted to updating only their email and full name</li>
    * </ul>
-   *
-   * <p>Additionally enforces field-level restrictions for non-administrators.
    *
    * @param user      the target user whose profile is being modified
    * @param operation the patch operation containing the field path and new value
@@ -107,11 +111,15 @@ public class PatchUserHandler {
     Assert.isTrue(StringUtils.isNotEmpty(path), "The 'path' must not be null");
 
     boolean isAdmin = SecurityContextUtils.isAdminRole();
+    boolean isOwnProfile = SecurityContextUtils.getPrincipal().getUserId().equals(user.getId());
+
     if (isAdmin) {
+      if (isOwnProfile && ADMIN_SELF_RESTRICTED_PATHS.contains(path)) {
+        throw new ReportPortalException(ErrorType.ACCESS_DENIED,
+            "Administrators cannot change their own account type, external ID, active status or instance role.");
+      }
       return;
     }
-
-    boolean isOwnProfile = SecurityContextUtils.getPrincipal().getUserId().equals(user.getId());
 
     if (!isOwnProfile) {
       throw new ReportPortalException(ErrorType.ACCESS_DENIED, "You are not allowed to update this user's profile.");

--- a/src/test/java/com/epam/reportportal/base/core/user/patch/PatchUserHandlerTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/patch/PatchUserHandlerTest.java
@@ -199,6 +199,80 @@ class PatchUserHandlerTest {
     verify(userMutationService).updateEmail(targetUser, "admin_new@example.com", principalUser);
   }
 
+  // --- Test Cases for Admin Self-Update Restrictions ---
+
+  @Test
+  @DisplayName("Admin updates own account_type - Should fail with ACCESS_DENIED")
+  void adminUpdatesOwnAccountTypeShouldFail() {
+    targetUser.setId(principalUser.getUserId());
+    mockPrincipal(principalUser, true);
+    when(userService.findById(targetUser.getId())).thenReturn(targetUser);
+
+    PatchOperation op = new PatchOperation();
+    op.setOp(REPLACE);
+    op.setPath("/account_type");
+    op.setValue("SCIM");
+    ReportPortalException exception = assertThrows(ReportPortalException.class,
+        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+
+    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
+    verify(userMutationService, never()).updateAccountType(any(), any());
+  }
+
+  @Test
+  @DisplayName("Admin updates own external_id - Should fail with ACCESS_DENIED")
+  void adminUpdatesOwnExternalIdShouldFail() {
+    targetUser.setId(principalUser.getUserId());
+    mockPrincipal(principalUser, true);
+    when(userService.findById(targetUser.getId())).thenReturn(targetUser);
+
+    PatchOperation op = new PatchOperation();
+    op.setOp(REPLACE);
+    op.setPath("/external_id");
+    op.setValue("new_external_id");
+    ReportPortalException exception = assertThrows(ReportPortalException.class,
+        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+
+    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
+    verify(userMutationService, never()).updateExternalId(any(), any());
+  }
+
+  @Test
+  @DisplayName("Admin updates own active status - Should fail with ACCESS_DENIED")
+  void adminUpdatesOwnActiveShouldFail() {
+    targetUser.setId(principalUser.getUserId());
+    mockPrincipal(principalUser, true);
+    when(userService.findById(targetUser.getId())).thenReturn(targetUser);
+
+    PatchOperation op = new PatchOperation();
+    op.setOp(REPLACE);
+    op.setPath("/active");
+    op.setValue(Boolean.FALSE);
+    ReportPortalException exception = assertThrows(ReportPortalException.class,
+        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+
+    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
+    verify(userMutationService, never()).updateActive(any(), any());
+  }
+
+  @Test
+  @DisplayName("Admin updates own instance_role - Should fail with ACCESS_DENIED")
+  void adminUpdatesOwnInstanceRoleShouldFail() {
+    targetUser.setId(principalUser.getUserId());
+    mockPrincipal(principalUser, true);
+    when(userService.findById(targetUser.getId())).thenReturn(targetUser);
+
+    PatchOperation op = new PatchOperation();
+    op.setOp(REPLACE);
+    op.setPath("/instance_role");
+    op.setValue(UserRole.USER.name());
+    ReportPortalException exception = assertThrows(ReportPortalException.class,
+        () -> patchUserHandler.patchUser(targetUser.getId(), Collections.singletonList(op)));
+
+    assertEquals(ErrorType.ACCESS_DENIED, exception.getErrorType());
+    verify(userMutationService, never()).updateInstanceRole(any(), any(), any());
+  }
+
   // --- Test Cases for UPSA Users ---
 
   @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Administrators can no longer change their own account type, external ID, active status, or instance role.
  * Restricted self-updates are rejected with an `ACCESS_DENIED` error.
  * Administrators can still update these settings for other users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->