### PR TITLE
EPMRPP-116918 || enhance error handling

### DIFF
--- a/src/main/java/com/epam/reportportal/base/exception/ExceptionMappings.java
+++ b/src/main/java/com/epam/reportportal/base/exception/ExceptionMappings.java
@@ -29,6 +29,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -74,6 +75,8 @@ public final class ExceptionMappings {
       .put(UnsupportedOperationException.class,
           new RestErrorDefinition<>(400, ErrorType.INCORRECT_REQUEST, DEFAULT_MESSAGE_BUILDER))
       .put(jakarta.validation.ConstraintViolationException.class,
+          new RestErrorDefinition<>(400, ErrorType.INCORRECT_REQUEST, DEFAULT_MESSAGE_BUILDER))
+      .put(MissingPathVariableException.class,
           new RestErrorDefinition<>(400, ErrorType.INCORRECT_REQUEST, DEFAULT_MESSAGE_BUILDER))
       .put(Throwable.class, new RestErrorDefinition<>(500, ErrorType.UNCLASSIFIED_ERROR, DEFAULT_MESSAGE_BUILDER))
       .build();

--- a/src/main/java/com/epam/reportportal/base/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/epam/reportportal/base/exception/handler/GlobalExceptionHandler.java
@@ -33,6 +33,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -70,6 +71,7 @@ public class GlobalExceptionHandler {
       HttpMessageNotReadableException.class,
       MissingServletRequestPartException.class,
       MissingServletRequestParameterException.class,
+      MissingPathVariableException.class,
       IllegalArgumentException.class,
       UnsupportedOperationException.class,
       jakarta.validation.ConstraintViolationException.class,

--- a/src/test/java/com/epam/reportportal/base/ws/controller/OrganizationIntegrationsControllerTest.java
+++ b/src/test/java/com/epam/reportportal/base/ws/controller/OrganizationIntegrationsControllerTest.java
@@ -65,6 +65,13 @@ class OrganizationIntegrationsControllerTest extends BaseMvcTest {
   }
 
   @Test
+  void getIntegrations_admin_ok123() throws Exception {
+    mockMvc.perform(get("/organizations/ /integrations")
+            .with(token(adminToken)))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
   void getIntegrations_manager_ok() throws Exception {
     mockMvc.perform(get("/organizations/201/integrations")
             .with(token(managerToken)))

--- a/src/test/java/com/epam/reportportal/base/ws/controller/OrganizationIntegrationsControllerTest.java
+++ b/src/test/java/com/epam/reportportal/base/ws/controller/OrganizationIntegrationsControllerTest.java
@@ -65,7 +65,7 @@ class OrganizationIntegrationsControllerTest extends BaseMvcTest {
   }
 
   @Test
-  void getIntegrations_admin_ok123() throws Exception {
+  void getIntegrations_blankOrgId_badRequest() throws Exception {
     mockMvc.perform(get("/organizations/ /integrations")
             .with(token(adminToken)))
         .andExpect(status().is4xxClientError());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Requests with missing or blank organization path information now return a clear 400 client error instead of causing an unexpected server error.
- **Tests**
  - Added coverage to verify the corrected response for invalid organization paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->