### PR TITLE
plugin-startup || Add single-threaded executor for plugin loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,8 +156,26 @@ sourceSets {
         java {
             srcDirs "$buildDir/generated/src/main/java"
         }
+        resources {
+            srcDir "$buildDir/generated/spring-modulith"
+        }
     }
 }
+
+tasks.register('generateModulithMetadata', JavaExec) {
+    dependsOn tasks.named('compileJava')
+    group = 'build'
+    description = 'Precomputes Spring Modulith application module metadata (ArchUnit classpath scan) at build ' +
+            'time, so the app loads it from the classpath instead of repeating the scan on every startup.'
+    mainClass.set('com.epam.reportportal.base.modulith.ApplicationModulesMetadataGenerator')
+    classpath = files(sourceSets.main.java.classesDirectory) + configurations.runtimeClasspath
+    def outputFile = layout.buildDirectory.file(
+            'generated/spring-modulith/META-INF/spring-modulith/application-modules.json')
+    outputs.file(outputFile)
+    args = [outputFile.get().asFile.absolutePath]
+}
+
+processResources.dependsOn tasks.named('generateModulithMetadata')
 
 openApiGenerate {
     generatorName.set("spring")
@@ -165,7 +183,7 @@ openApiGenerate {
     outputDir.set(layout.buildDirectory.dir("generated"))
     configFile.set(file("$rootDir/src/main/resources/openapi/config.json"))
     skipOverwrite.set(false)
-    cleanupOutput.set(true)
+    cleanupOutput.set(false)
     workerIsolation.set("process")
     // verbose.set(true)
 }

--- a/src/main/java/com/epam/reportportal/base/core/configs/ExecutorConfiguration.java
+++ b/src/main/java/com/epam/reportportal/base/core/configs/ExecutorConfiguration.java
@@ -169,4 +169,21 @@ public class ExecutorConfiguration {
     return threadPoolTaskExecutor;
   }
 
+  /**
+   * Single-threaded on purpose: plugin loading already runs one plugin at a time
+   * ({@link com.epam.reportportal.base.plugin.Pf4jPluginManager#startUp()}), and running several
+   * plugin classloaders concurrently would only raise the peak memory this executor is meant to
+   * avoid.
+   */
+  @Bean(name = "pluginStartupExecutor")
+  public TaskExecutor pluginStartupExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(1);
+    executor.setMaxPoolSize(1);
+    executor.setQueueCapacity(1);
+    executor.setThreadNamePrefix("plugin-startup-exec");
+    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+    return executor;
+  }
+
 }

--- a/src/main/java/com/epam/reportportal/base/modulith/ApplicationModulesMetadataGenerator.java
+++ b/src/main/java/com/epam/reportportal/base/modulith/ApplicationModulesMetadataGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.modulith;
+
+import com.epam.reportportal.ReportPortalApp;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.springframework.modulith.core.ApplicationModules;
+import org.springframework.modulith.core.util.ApplicationModulesExporter;
+
+/**
+ * Build-time-only entry point (invoked by the {@code generateModulithMetadata} Gradle task, never packaged as a
+ * running part of the application). Runs the same {@link ApplicationModules#of(Class)} ArchUnit classpath scan that
+ * Spring Modulith would otherwise perform on every application startup, and writes the result to
+ * {@link ApplicationModulesExporter#DEFAULT_LOCATION} on the compiled resources path. When that resource is present
+ * on the runtime classpath, Spring Modulith's {@code PrecomputedApplicationModuleInitializerInvoker} uses it
+ * directly instead of re-running the scan at boot, removing a memory/CPU spike from application startup.
+ */
+public final class ApplicationModulesMetadataGenerator {
+
+  private ApplicationModulesMetadataGenerator() {
+  }
+
+  public static void main(String[] args) throws IOException {
+    Path output = Path.of(args[0]);
+    Files.createDirectories(output.getParent());
+
+    ApplicationModules modules = ApplicationModules.of(ReportPortalApp.class);
+    Files.writeString(output, new ApplicationModulesExporter(modules).toFullJson());
+  }
+}

--- a/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
+++ b/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
@@ -145,19 +145,26 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
   @Override
   public void startUp() {
     // load and start all enabled plugins of application
-    integrationTypeRepository.findAll()
+    List<IntegrationType> pluginsToLoad = integrationTypeRepository.findAll()
         .stream()
         .filter(IntegrationType::isEnabled)
         .filter(it -> it.getPluginType() == EXTENSION)
-        .forEach(integrationType -> ofNullable(integrationType.getDetails()).ifPresent(
-            integrationTypeDetails -> {
-              try {
-                loadPlugin(integrationType.getName(), integrationTypeDetails);
-              } catch (Exception ex) {
-                LOGGER.error("Unable to load plugin '{}'", integrationType.getName());
-              }
-            }));
+        .toList();
 
+    LOGGER.info("Plugin startup: loading {} enabled extension plugin(s)", pluginsToLoad.size());
+    long startUpBegin = System.currentTimeMillis();
+
+    pluginsToLoad.forEach(integrationType -> ofNullable(integrationType.getDetails()).ifPresent(
+        integrationTypeDetails -> {
+          try {
+            loadPlugin(integrationType.getName(), integrationTypeDetails);
+          } catch (Exception ex) {
+            LOGGER.error("Unable to load plugin '{}'", integrationType.getName());
+          }
+        }));
+
+    LOGGER.info("Plugin startup: finished loading {} plugin(s) in {} ms", pluginsToLoad.size(),
+        System.currentTimeMillis() - startUpBegin);
   }
 
   @Override
@@ -180,6 +187,7 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
 
   @Override
   public boolean loadPlugin(String pluginId, IntegrationTypeDetails integrationTypeDetails) {
+    long loadBegin = System.currentTimeMillis();
     return ofNullable(integrationTypeDetails.getDetails()).map(details -> {
       String fileName = IntegrationTypeProperties.FILE_NAME.getValue(details)
           .map(String::valueOf)
@@ -189,7 +197,8 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
           ));
 
       Path pluginPath = Paths.get(pluginsDir, fileName);
-      if (Files.notExists(pluginPath)) {
+      boolean cached = Files.exists(pluginPath);
+      if (!cached) {
         String fileId = IntegrationTypeProperties.FILE_ID.getValue(details)
             .map(String::valueOf)
             .orElseThrow(() -> new ReportPortalException(ErrorType.PLUGIN_UPLOAD_ERROR,
@@ -208,7 +217,7 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
         copyPluginResources(pluginPath, pluginId);
       }
 
-      return ofNullable(pluginManager.loadPlugin(pluginPath)).map(id -> {
+      boolean result = ofNullable(pluginManager.loadPlugin(pluginPath)).map(id -> {
         if (PluginState.STARTED == pluginManager.startPlugin(pluginId)) {
           initPlugin(pluginId);
           applicationEventPublisher.publishEvent(
@@ -219,8 +228,23 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
           return false;
         }
       }).orElse(Boolean.FALSE);
+
+      LOGGER.info(
+          "Plugin '{}' load finished: success={} cached={} sizeBytes={} tookMs={}",
+          pluginId, result, cached, fileSizeOrUnknown(pluginPath),
+          System.currentTimeMillis() - loadBegin
+      );
+      return result;
     }).orElse(Boolean.FALSE);
 
+  }
+
+  private long fileSizeOrUnknown(Path path) {
+    try {
+      return Files.size(path);
+    } catch (IOException e) {
+      return -1;
+    }
   }
 
   private void initPlugin(String pluginId) {

--- a/src/main/java/com/epam/reportportal/base/plugin/PluginStartUpService.java
+++ b/src/main/java/com/epam/reportportal/base/plugin/PluginStartUpService.java
@@ -22,7 +22,6 @@ import com.epam.reportportal.base.core.plugin.Pf4jPluginBox;
 import com.epam.reportportal.base.infrastructure.persistence.dao.IntegrationTypeRepository;
 import com.epam.reportportal.extension.common.IntegrationTypeProperties;
 import com.google.common.collect.Lists;
-import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -39,10 +38,18 @@ import org.pf4j.update.SimpleFileDownloader;
 import org.pf4j.update.UpdateManager;
 import org.pf4j.update.UpdateRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 /**
  * Optional download and load of default plugins on application startup.
+ *
+ * <p>Runs after the application context has finished refreshing and readiness probes can pass,
+ * rather than blocking context startup ({@code @PostConstruct}) - loading every enabled plugin
+ * eagerly on the same thread as the rest of the bean graph stacks its memory footprint on top of
+ * Spring's own startup peak.
  *
  * @author <a href="mailto:pavel_bortnik@epam.com">Pavel Bortnik</a>
  */
@@ -57,7 +64,8 @@ public class PluginStartUpService {
   @Value("${rp.plugins.default.load}")
   private boolean defaultPluginsLoad;
 
-  @PostConstruct
+  @Async("pluginStartupExecutor")
+  @EventListener(ApplicationReadyEvent.class)
   public void loadPlugins() {
     pluginBox.startUp();
     if (defaultPluginsLoad) {


### PR DESCRIPTION
… improve logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added generated application module metadata for improved system visibility.
  - Plugin loading now starts asynchronously after the application is ready, improving startup responsiveness.
  - Added detailed plugin startup and loading progress information, including duration, cache status, and file size.

- **Bug Fixes**
  - Plugin startup now continues when an individual plugin fails to load, preventing one failure from blocking others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->