### PR TITLE
Feature/epmrpp 118810 increase tms attribute length

### DIFF
--- a/project-properties.gradle
+++ b/project-properties.gradle
@@ -107,7 +107,8 @@ project.ext {
             (migrationsUrl + '/migrations/218_increase_activity_name_length.up.sql')                     : 'V218__increase_activity_name_length.up.sql',
             (migrationsUrl + '/migrations/219_revoked_token.up.sql')                                     : 'V219__revoked_token.up.sql',
             (migrationsUrl + '/migrations/220_increase_tms_test_plan_description_length.up.sql')         : 'V220__increase_tms_test_plan_description_length.up.sql',
-            (migrationsUrl + '/migrations/221_increase_tms_manual_scenario_preconditions_length.up.sql') : 'V221__increase_tms_manual_scenario_preconditions_length.up.sql'
+            (migrationsUrl + '/migrations/221_increase_tms_manual_scenario_preconditions_length.up.sql') : 'V221__increase_tms_manual_scenario_preconditions_length.up.sql',
+            (migrationsUrl + '/migrations/222_increase_tms_attribute_length.up.sql')                     : 'V222__increase_tms_attribute_length.up.sql'
     ]
     excludeTests = ['**/entity/**',
                     '**/aop/**',

--- a/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsAttributeRQ.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsAttributeRQ.java
@@ -1,6 +1,7 @@
 package com.epam.reportportal.base.core.tms.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +14,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TmsAttributeRQ {
 
+  @Size(max = 512)
   private String key;
 
+  @Size(max = 512)
   private String value;
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsDatasetDataRQ.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsDatasetDataRQ.java
@@ -1,5 +1,6 @@
 package com.epam.reportportal.base.core.tms.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TmsDatasetDataRQ {
 
+  @Size(max = 512)
   private String key;
+  
+  @Size(max = 512)
   private String value;
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsManualLaunchAttributeRQ.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsManualLaunchAttributeRQ.java
@@ -1,6 +1,7 @@
 package com.epam.reportportal.base.core.tms.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,5 +16,6 @@ public class TmsManualLaunchAttributeRQ {
 
   private Long id;
 
+  @Size(max = 512)
   private String value;
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsTestCaseAttributeImportRQ.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsTestCaseAttributeImportRQ.java
@@ -1,5 +1,6 @@
 package com.epam.reportportal.base.core.tms.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,5 +12,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class TmsTestCaseAttributeImportRQ {
 
+  @Size(max = 512)
   private String key;
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsTestCaseAttributeRQ.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsTestCaseAttributeRQ.java
@@ -1,6 +1,7 @@
 package com.epam.reportportal.base.core.tms.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,5 +16,6 @@ public class TmsTestCaseAttributeRQ {
 
   private Long id;
 
+  @Size(max = 512)
   private String key;
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsTestPlanAttributeRQ.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/dto/TmsTestPlanAttributeRQ.java
@@ -1,6 +1,7 @@
 package com.epam.reportportal.base.core.tms.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
@@ -9,7 +10,9 @@ public class TmsTestPlanAttributeRQ {
 
   private Long id;
 
+  @Size(max = 512)
   private String key;
 
+  @Size(max = 512)
   private String value;
 }

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/tms/TmsAttribute.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/entity/tms/TmsAttribute.java
@@ -29,10 +29,10 @@ public class TmsAttribute implements Serializable {
   @Column(name = "id")
   private Long id;
 
-  @Column(name = "key", nullable = false)
+  @Column(name = "key", nullable = false, length = 512)
   private String key;
 
-  @Column(name = "value")
+  @Column(name = "value", length = 512)
   private String value;
 
   @ManyToOne

--- a/src/main/java/com/epam/reportportal/base/infrastructure/persistence/jooq/tables/JTmsAttribute.java
+++ b/src/main/java/com/epam/reportportal/base/infrastructure/persistence/jooq/tables/JTmsAttribute.java
@@ -8,16 +8,15 @@ import com.epam.reportportal.base.infrastructure.persistence.jooq.Indexes;
 import com.epam.reportportal.base.infrastructure.persistence.jooq.JPublic;
 import com.epam.reportportal.base.infrastructure.persistence.jooq.Keys;
 import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JProject.JProjectPath;
-import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsManualScenario.JTmsManualScenarioPath;
 import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsManualScenarioAttribute.JTmsManualScenarioAttributePath;
-import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsTestCase.JTmsTestCasePath;
+import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsManualScenario.JTmsManualScenarioPath;
 import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsTestCaseAttribute.JTmsTestCaseAttributePath;
-import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsTestPlan.JTmsTestPlanPath;
+import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsTestCase.JTmsTestCasePath;
 import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsTestPlanAttribute.JTmsTestPlanAttributePath;
+import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.JTmsTestPlan.JTmsTestPlanPath;
 import com.epam.reportportal.base.infrastructure.persistence.jooq.tables.records.JTmsAttributeRecord;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import org.jooq.Condition;
@@ -28,13 +27,8 @@ import org.jooq.Index;
 import org.jooq.InverseForeignKey;
 import org.jooq.Name;
 import org.jooq.Path;
-import org.jooq.PlainSQL;
-import org.jooq.QueryPart;
 import org.jooq.Record;
-import org.jooq.SQL;
 import org.jooq.Schema;
-import org.jooq.Select;
-import org.jooq.Stringly;
 import org.jooq.Table;
 import org.jooq.TableField;
 import org.jooq.TableOptions;
@@ -73,12 +67,12 @@ public class JTmsAttribute extends TableImpl<JTmsAttributeRecord> {
     /**
      * The column <code>public.tms_attribute.key</code>.
      */
-    public final TableField<JTmsAttributeRecord, String> KEY = createField(DSL.name("key"), SQLDataType.VARCHAR(255).nullable(false), this, "");
+    public final TableField<JTmsAttributeRecord, String> KEY = createField(DSL.name("key"), SQLDataType.VARCHAR(512).nullable(false), this, "");
 
     /**
      * The column <code>public.tms_attribute.value</code>.
      */
-    public final TableField<JTmsAttributeRecord, String> VALUE = createField(DSL.name("value"), SQLDataType.VARCHAR(255), this, "");
+    public final TableField<JTmsAttributeRecord, String> VALUE = createField(DSL.name("value"), SQLDataType.VARCHAR(512), this, "");
 
     /**
      * The column <code>public.tms_attribute.project_id</code>.
@@ -289,89 +283,5 @@ public class JTmsAttribute extends TableImpl<JTmsAttributeRecord> {
     @Override
     public JTmsAttribute rename(Table<?> name) {
         return new JTmsAttribute(name.getQualifiedName(), null);
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    public JTmsAttribute where(Condition condition) {
-        return new JTmsAttribute(getQualifiedName(), aliased() ? this : null, null, condition);
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    public JTmsAttribute where(Collection<? extends Condition> conditions) {
-        return where(DSL.and(conditions));
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    public JTmsAttribute where(Condition... conditions) {
-        return where(DSL.and(conditions));
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    public JTmsAttribute where(Field<Boolean> condition) {
-        return where(DSL.condition(condition));
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    @PlainSQL
-    public JTmsAttribute where(SQL condition) {
-        return where(DSL.condition(condition));
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    @PlainSQL
-    public JTmsAttribute where(@Stringly.SQL String condition) {
-        return where(DSL.condition(condition));
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    @PlainSQL
-    public JTmsAttribute where(@Stringly.SQL String condition, Object... binds) {
-        return where(DSL.condition(condition, binds));
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    @PlainSQL
-    public JTmsAttribute where(@Stringly.SQL String condition, QueryPart... parts) {
-        return where(DSL.condition(condition, parts));
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    public JTmsAttribute whereExists(Select<?> select) {
-        return where(DSL.exists(select));
-    }
-
-    /**
-     * Create an inline derived table from this table
-     */
-    @Override
-    public JTmsAttribute whereNotExists(Select<?> select) {
-        return where(DSL.notExists(select));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum length for TMS attribute keys and values from 255 to 512 characters.
  * Applied the expanded limit consistently across test cases, test plans, datasets, manual launches, and imported attributes.
* **Bug Fixes**
  * Added validation to provide clearer feedback when attribute keys or values exceed 512 characters.
  * Updated data storage to support longer attributes without truncation or persistence errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->