### PR TITLE
Fix TMS sync attachments linking and make JiraHttpClient a singleton bean

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/tms/sync/connector/jira/JiraHttpClient.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/sync/connector/jira/JiraHttpClient.java
@@ -1,0 +1,123 @@
+package com.epam.reportportal.base.core.tms.sync.connector.jira;
+
+import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
+import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JiraHttpClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JiraHttpClient.class);
+
+    private final CloseableHttpClient httpClient;
+
+    public JiraHttpClient() {
+        var requestConfig = RequestConfig.custom()
+                .setConnectTimeout(Timeout.ofSeconds(30))
+                .setResponseTimeout(Timeout.ofSeconds(60))
+                .build();
+
+        this.httpClient = HttpClients.custom()
+                .setDefaultRequestConfig(requestConfig)
+                .setRetryStrategy(new DefaultHttpRequestRetryStrategy(3, TimeValue.ofSeconds(1L)))
+                .build();
+    }
+
+    public InputStream downloadAttachmentStream(String bearerToken, String contentUrl) throws IOException {
+        LOGGER.info("Downloading attachment from URL: {}", contentUrl);
+
+        var request = new HttpGet(contentUrl);
+        request.setHeader("Authorization", "Bearer " + bearerToken);
+        request.setHeader("User-Agent", "ReportPortal-TMS-Sync/1.0");
+
+        CloseableHttpResponse response = httpClient.execute(request);
+
+        if (response.getCode() >= 400) {
+            EntityUtils.consumeQuietly(response.getEntity());
+            response.close();
+            throw new IOException("Failed to download attachment. HTTP Code: " + response.getCode());
+        }
+
+        if (response.getEntity() == null) {
+            response.close();
+            throw new IOException("Response body is null for URL: " + contentUrl);
+        }
+
+        // Wrap the InputStream to ensure the CloseableHttpResponse is closed when the stream is closed
+        InputStream originalStream = response.getEntity().getContent();
+        return new FilterInputStream(originalStream) {
+            @Override
+            public void close() throws IOException {
+                try {
+                    super.close();
+                } finally {
+                    response.close();
+                }
+            }
+        };
+    }
+
+    public String get(String jiraBaseUrl, String bearerToken, String path) {
+        var url = jiraBaseUrl.endsWith("/") ? jiraBaseUrl + path : jiraBaseUrl + "/" + path;
+
+        var request = new HttpGet(url);
+        request.setHeader("Authorization", "Bearer " + bearerToken);
+        request.setHeader("Accept", "application/json");
+        request.setHeader("User-Agent", "ReportPortal-TMS-Sync/1.0");
+
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            if (response.getCode() >= 400) {
+                throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR,
+                    "Jira API request failed. HTTP Code: " + response.getCode());
+            }
+            if (response.getEntity() == null) {
+                throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Jira API response body is null");
+            }
+            return EntityUtils.toString(response.getEntity());
+        } catch (IOException | ParseException e) {
+            throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Failed to execute Jira API request: " + e.getMessage());
+        }
+    }
+
+    public String post(String jiraBaseUrl, String bearerToken, String path, String jsonBody) {
+        var url = jiraBaseUrl.endsWith("/") ? jiraBaseUrl + path : jiraBaseUrl + "/" + path;
+
+        var request = new HttpPost(url);
+        request.setHeader("Authorization", "Bearer " + bearerToken);
+        request.setHeader("Accept", "application/json");
+        request.setHeader("Content-Type", "application/json");
+        request.setHeader("User-Agent", "ReportPortal-TMS-Sync/1.0");
+        request.setEntity(new StringEntity(jsonBody, ContentType.APPLICATION_JSON));
+
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            if (response.getCode() >= 400) {
+                throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR,
+                    "Jira API request failed. HTTP Code: " + response.getCode());
+            }
+            if (response.getEntity() == null) {
+                throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Jira API response body is null");
+            }
+            return EntityUtils.toString(response.getEntity());
+        } catch (IOException | ParseException e) {
+            throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Failed to execute Jira API request: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/epam/reportportal/base/core/tms/sync/connector/jira/QaSpaceSyncConnector.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/sync/connector/jira/QaSpaceSyncConnector.java
@@ -1,0 +1,185 @@
+package com.epam.reportportal.base.core.tms.sync.connector.jira;
+
+import com.epam.reportportal.base.core.tms.enums.TmsSyncProvider;
+import com.epam.reportportal.base.core.tms.sync.TmsSyncConnector;
+import com.epam.reportportal.base.core.tms.sync.dto.RemoteAttachment;
+import com.epam.reportportal.base.core.tms.sync.dto.RemoteFolder;
+import com.epam.reportportal.base.core.tms.sync.dto.RemoteTestCase;
+import com.epam.reportportal.base.infrastructure.persistence.entity.integration.Integration;
+import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
+import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QaSpaceSyncConnector implements TmsSyncConnector<Integration> {
+
+    private static final String URL_PARAM = "url";
+    private static final String BEARER_PAT_PARAM = "bearerPat";
+    private static final String PROJECT_KEY_PARAM = "projectKey";
+
+    private final ObjectMapper objectMapper;
+    private final JiraHttpClient jiraHttpClient;
+
+    public QaSpaceSyncConnector(ObjectMapper objectMapper, JiraHttpClient jiraHttpClient) {
+        this.objectMapper = objectMapper;
+        this.jiraHttpClient = jiraHttpClient;
+    }
+
+    @Override
+    public TmsSyncProvider getSupportedProvider() {
+        return TmsSyncProvider.QA_SPACE;
+    }
+
+    @Override
+    public void validateConfig(Integration config) {
+        Map<String, Object> params = config.getParams().getParams();
+        if (!params.containsKey(URL_PARAM) || !params.containsKey(BEARER_PAT_PARAM) || !params.containsKey(PROJECT_KEY_PARAM)) {
+            throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Missing required integration parameters for QA Space");
+        }
+    }
+
+    @Override
+    public List<RemoteFolder> fetchFolderTree(Integration config, String rootFolderId) {
+        Map<String, Object> params = config.getParams().getParams();
+        String url = (String) params.get(URL_PARAM);
+        String bearerPat = (String) params.get(BEARER_PAT_PARAM);
+        String projectKey = (String) params.get(PROJECT_KEY_PARAM);
+
+        String path = String.format("rest/tm/1.0/folder/list?projectKey=%s&folderId=%s", projectKey, rootFolderId);
+        String response = jiraHttpClient.get(url, bearerPat, path);
+
+        List<RemoteFolder> folders = new ArrayList<>();
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            parseFoldersRecursive(rootNode, null, folders);
+        } catch (Exception e) {
+            throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Failed to parse QA Space folder tree", e);
+        }
+
+        return folders;
+    }
+
+    @Override
+    public void fetchTestCases(Integration config, String folderId, Instant since, Consumer<Integer> totalCountConsumer, Consumer<RemoteTestCase> testCaseConsumer) {
+        Map<String, Object> params = config.getParams().getParams();
+        String url = (String) params.get(URL_PARAM);
+        String bearerPat = (String) params.get(BEARER_PAT_PARAM);
+        String projectKey = (String) params.get(PROJECT_KEY_PARAM);
+
+        // 1. Fetch folder to get testCaseIds
+        String folderPath = String.format("rest/tm/1.0/folder/list?projectKey=%s&folderId=%s", projectKey, folderId);
+        String folderResponse = jiraHttpClient.get(url, bearerPat, folderPath);
+
+        List<String> testCaseIds = new ArrayList<>();
+        try {
+            JsonNode rootNode = objectMapper.readTree(folderResponse);
+            if (rootNode.has("testCaseIds")) {
+                rootNode.get("testCaseIds").forEach(idNode -> testCaseIds.add(idNode.asText()));
+            }
+        } catch (Exception e) {
+            throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Failed to parse QA Space folder test cases", e);
+        }
+
+        totalCountConsumer.accept(testCaseIds.size());
+
+        // 2. Fetch details for each test case in batches
+        int batchSize = 50;
+        for (int i = 0; i < testCaseIds.size(); i += batchSize) {
+            List<String> batch = testCaseIds.subList(i, Math.min(i + batchSize, testCaseIds.size()));
+
+            String jql = "issueKey in (" + String.join(",", batch) + ")";
+
+            ObjectNode searchReq = objectMapper.createObjectNode();
+            searchReq.put("jql", jql);
+            searchReq.putArray("fields")
+                .add("summary").add("description").add("updated")
+                .add("customfield_19206").add("customfield_19207").add("attachment");
+            searchReq.put("maxResults", batchSize);
+
+            String issueResponse = jiraHttpClient.post(url, bearerPat, "rest/api/2/search", searchReq.toString());
+
+            try {
+                JsonNode searchNode = objectMapper.readTree(issueResponse);
+                if (searchNode.has("issues")) {
+                    searchNode.get("issues").forEach(issueNode -> {
+                        String testCaseId = issueNode.get("key").asText();
+                        JsonNode fields = issueNode.get("fields");
+
+                        Instant updatedAt = Instant.now();
+                        if (fields.hasNonNull("updated")) {
+                            updatedAt = Instant.from(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parse(fields.get("updated").asText()));
+                        }
+
+                        if (since != null && updatedAt.isBefore(since)) {
+                            return; // Skip if not updated since last sync
+                        }
+
+                        List<RemoteAttachment> attachments = new ArrayList<>();
+                        if (fields.has("attachment")) {
+                            fields.get("attachment").forEach(attNode -> {
+                                attachments.add(RemoteAttachment.builder()
+                                        .id(attNode.get("id").asText())
+                                        .filename(attNode.get("filename").asText())
+                                        .mimeType(attNode.get("mimeType").asText())
+                                        .size(attNode.get("size").asLong())
+                                        .contentUrl(attNode.get("content").asText())
+                                        .build());
+                            });
+                        }
+
+                        RemoteTestCase remoteTestCase = RemoteTestCase.builder()
+                                .id(testCaseId)
+                                .name(fields.hasNonNull("summary") ? fields.get("summary").asText() : "")
+                                .description(fields.hasNonNull("description") ? fields.get("description").asText() : "")
+                                .steps(fields.hasNonNull("customfield_19206") ? fields.get("customfield_19206").asText() : "")
+                                .expectedResults(fields.hasNonNull("customfield_19207") ? fields.get("customfield_19207").asText() : "")
+                                .folderId(folderId)
+                                .updatedAt(updatedAt)
+                                .attachments(attachments)
+                                .build();
+
+                        testCaseConsumer.accept(remoteTestCase);
+                    });
+                }
+            } catch (Exception e) {
+                throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Failed to parse Jira search response", e);
+            }
+        }
+    }
+
+    @Override
+    public InputStream downloadAttachment(Integration config, String contentUrl) {
+        String bearerPat = (String) config.getParams().getParams().get(BEARER_PAT_PARAM);
+        try {
+            return jiraHttpClient.downloadAttachmentStream(bearerPat, contentUrl);
+        } catch (IOException e) {
+            throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "Failed to download attachment from Jira", e);
+        }
+    }
+
+    private void parseFoldersRecursive(JsonNode node, String parentId, List<RemoteFolder> folders) {
+        if (node.has("id") && node.has("name")) {
+            String id = node.get("id").asText();
+            folders.add(RemoteFolder.builder()
+                    .id(id)
+                    .name(node.get("name").asText())
+                    .parentId(parentId)
+                    .build());
+
+            if (node.has("children")) {
+                node.get("children").forEach(child -> parseFoldersRecursive(child, id, folders));
+            }
+        }
+    }
+}

--- a/src/main/java/com/epam/reportportal/base/core/tms/sync/service/TmsTestCaseSyncServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/sync/service/TmsTestCaseSyncServiceImpl.java
@@ -1,0 +1,249 @@
+package com.epam.reportportal.base.core.tms.sync.service;
+
+import com.epam.reportportal.base.core.tms.dto.TmsManualScenarioAttachmentRQ;
+import com.epam.reportportal.base.core.tms.dto.TmsManualScenarioPreconditionsRQ;
+import com.epam.reportportal.base.core.tms.dto.TmsManualScenarioType;
+import com.epam.reportportal.base.core.tms.dto.TmsTextManualScenarioRQ;
+import com.epam.reportportal.base.core.tms.mapper.TmsTestFolderMapper;
+import com.epam.reportportal.base.core.tms.service.TmsTestCaseVersionService;
+import com.epam.reportportal.base.core.tms.sync.TmsSyncConnector;
+import com.epam.reportportal.base.core.tms.sync.dto.RemoteTestCase;
+import com.epam.reportportal.base.infrastructure.persistence.binary.tms.TmsAttachmentDataStoreService;
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsAttachmentRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsSyncJobRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestCaseRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.integration.Integration;
+import com.epam.reportportal.base.infrastructure.persistence.entity.project.Project;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsAttachment;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestCase;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.sync.SyncError;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+@Service
+public class TmsTestCaseSyncServiceImpl implements TmsTestCaseSyncService {
+
+  private final TmsTestCaseRepository tmsTestCaseRepository;
+  private final TmsTestCaseVersionService tmsTestCaseVersionService;
+  private final TmsAttachmentDataStoreService tmsAttachmentDataStoreService;
+  private final TmsAttachmentRepository tmsAttachmentRepository;
+  private final TmsSyncJobRepository tmsSyncJobRepository;
+  private final TmsTestFolderMapper tmsTestFolderMapper;
+  private final TransactionTemplate transactionTemplate;
+
+  public TmsTestCaseSyncServiceImpl(
+      TmsTestCaseRepository tmsTestCaseRepository,
+      TmsTestCaseVersionService tmsTestCaseVersionService,
+      TmsAttachmentDataStoreService tmsAttachmentDataStoreService,
+      TmsAttachmentRepository tmsAttachmentRepository,
+      TmsSyncJobRepository tmsSyncJobRepository,
+      TmsTestFolderMapper tmsTestFolderMapper,
+      PlatformTransactionManager transactionManager) {
+    this.tmsTestCaseRepository = tmsTestCaseRepository;
+    this.tmsTestCaseVersionService = tmsTestCaseVersionService;
+    this.tmsAttachmentDataStoreService = tmsAttachmentDataStoreService;
+    this.tmsAttachmentRepository = tmsAttachmentRepository;
+    this.tmsSyncJobRepository = tmsSyncJobRepository;
+    this.tmsTestFolderMapper = tmsTestFolderMapper;
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
+    this.transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+  }
+
+  @Override
+  public void processTestCaseBatch(Long jobId, Long projectId,
+      TmsSyncConnector<Integration> connector, Integration integration, List<RemoteTestCase> batch,
+      Long localFolderId) {
+    List<String> externalIds = batch.stream().map(RemoteTestCase::getId).toList();
+
+    // 1. Fetch existing in one query
+    Map<String, TmsTestCase> existingTestCases = transactionTemplate.execute(status ->
+        tmsTestCaseRepository.findByProjectIdAndExternalIdIn(projectId, externalIds)
+            .stream()
+            .collect(Collectors.toMap(TmsTestCase::getExternalId, tc -> tc))
+    );
+
+    List<TmsTestCase> testCasesToSave = new ArrayList<>();
+    Map<String, Boolean> isNewMap = new HashMap<>();
+    Map<String, List<TmsAttachment>> attachmentsPerTestCase = new HashMap<>();
+    int processedCount = 0;
+    int failedCount = 0;
+    List<SyncError> errors = new ArrayList<>();
+
+    for (var remoteTestCase : batch) {
+      try {
+        TmsTestCase existing =
+            existingTestCases != null ? existingTestCases.get(remoteTestCase.getId()) : null;
+        boolean needsUpdate = existing == null || existing.getSourceUpdatedAt() == null
+            || remoteTestCase.getUpdatedAt().isAfter(existing.getSourceUpdatedAt());
+
+        if (!needsUpdate) {
+          continue;
+        }
+
+        // 2. Process Attachments (Network + Datastore I/O - NO DB TRANSACTION)
+        List<TmsAttachment> testCaseAttachments = new ArrayList<>();
+        if (remoteTestCase.getAttachments() != null) {
+          for (var remoteAttachment : remoteTestCase.getAttachments()) {
+            try (InputStream inputStream = connector.downloadAttachment(integration,
+                remoteAttachment.getContentUrl())) {
+
+              String sanitizedFilename = remoteAttachment.getFilename()
+                  .replaceAll("[^a-zA-Z0-9.-]", "_");
+              String shardedPath = String.format("tms/%d/%s/%s_%s",
+                  projectId, remoteTestCase.getId(), remoteAttachment.getId(), sanitizedFilename);
+
+              var fileId = tmsAttachmentDataStoreService.save(shardedPath, inputStream);
+
+              var attachment = new TmsAttachment();
+              attachment.setFileName(remoteAttachment.getFilename());
+              attachment.setFileType(remoteAttachment.getMimeType());
+              attachment.setFileSize(remoteAttachment.getSize());
+              attachment.setPathToFile(fileId);
+              attachment.setExpiresAt(null);
+              testCaseAttachments.add(attachment);
+            } catch (Exception e) {
+              log.warn("Failed to sync attachment {} for test case {}", remoteAttachment.getId(),
+                  remoteTestCase.getId(), e);
+              errors.add(new SyncError(remoteAttachment.getId(),
+                  "Attachment sync failed: " + e.getMessage(), null));
+            }
+          }
+        }
+        if (!testCaseAttachments.isEmpty()) {
+          attachmentsPerTestCase.put(remoteTestCase.getId(), testCaseAttachments);
+        }
+
+        TmsTestCase testCase = existing != null ? existing : new TmsTestCase();
+        if (existing == null) {
+          var project = new Project();
+          project.setId(projectId);
+          testCase.setProject(project);
+          testCase.setExternalId(remoteTestCase.getId());
+          isNewMap.put(remoteTestCase.getId(), true);
+        } else {
+          isNewMap.put(remoteTestCase.getId(), false);
+        }
+
+        testCase.setName(remoteTestCase.getName());
+        testCase.setDescription(remoteTestCase.getDescription());
+        testCase.setSourceUpdatedAt(remoteTestCase.getUpdatedAt());
+
+        if (localFolderId != null) {
+          testCase.setTestFolder(tmsTestFolderMapper.convertFromId(localFolderId));
+        }
+
+        testCasesToSave.add(testCase);
+        processedCount++;
+      } catch (Exception e) {
+        log.error("Failed to sync test case: {}", remoteTestCase.getId(), e);
+        failedCount++;
+        errors.add(
+            new SyncError(remoteTestCase.getId(), e.getMessage(), ExceptionUtils.getStackTrace(e)));
+      }
+    }
+
+    // 3. Save Batch (Short DB Write Transaction)
+    final int finalProcessedCount = processedCount;
+    final int finalFailedCount = failedCount;
+    transactionTemplate.execute(status -> {
+      List<TmsAttachment> allAttachments = attachmentsPerTestCase.values().stream()
+          .flatMap(List::stream)
+          .toList();
+      if (!allAttachments.isEmpty()) {
+        tmsAttachmentRepository.saveAll(allAttachments);
+      }
+
+      if (!testCasesToSave.isEmpty()) {
+        List<TmsTestCase> savedTestCases = tmsTestCaseRepository.saveAll(testCasesToSave);
+        Map<String, TmsTestCase> savedMap = savedTestCases.stream()
+            .collect(Collectors.toMap(TmsTestCase::getExternalId, tc -> tc, (tc1, tc2) -> tc1));
+
+        for (var remoteTestCase : batch) {
+          Boolean isNew = isNewMap.get(remoteTestCase.getId());
+          if (isNew != null) {
+            TmsTestCase savedCase = savedMap.get(remoteTestCase.getId());
+            if (savedCase != null) {
+              List<TmsAttachment> savedAttachments = attachmentsPerTestCase.get(remoteTestCase.getId());
+              TmsTextManualScenarioRQ manualScenarioRQ = buildManualScenarioRQ(remoteTestCase, savedAttachments);
+              if (Boolean.TRUE.equals(isNew)) {
+                tmsTestCaseVersionService.createDefaultTestCaseVersion(projectId, savedCase, manualScenarioRQ);
+              } else {
+                tmsTestCaseVersionService.updateDefaultTestCaseVersion(projectId, savedCase, manualScenarioRQ);
+              }
+            }
+          }
+        }
+      }
+
+      var job = tmsSyncJobRepository.findById(jobId).orElseThrow();
+      job.getCounters().setProcessed(job.getCounters().getProcessed() + finalProcessedCount);
+      job.getCounters().setFailed(job.getCounters().getFailed() + finalFailedCount);
+      if (!errors.isEmpty()) {
+        job.getErrorLog().getErrors().addAll(errors);
+      }
+      return tmsSyncJobRepository.save(job);
+    });
+  }
+
+  private TmsTextManualScenarioRQ buildManualScenarioRQ(RemoteTestCase remoteTestCase,
+      List<TmsAttachment> attachments) {
+    String rawSteps = remoteTestCase.getSteps();
+    String preconditionsText = null;
+    String instructionsText = rawSteps;
+
+    if (StringUtils.isNotBlank(rawSteps)) {
+      if (rawSteps.contains("*Preconditions*:")) {
+        int preconditionsIdx = rawSteps.indexOf("*Preconditions*:");
+        int stepsIdx = rawSteps.indexOf("*Steps*:");
+        if (stepsIdx > preconditionsIdx) {
+          preconditionsText = rawSteps.substring(preconditionsIdx + "*Preconditions*:".length(), stepsIdx).trim();
+          instructionsText = rawSteps.substring(stepsIdx + "*Steps*:".length()).trim();
+        } else {
+          preconditionsText = rawSteps.substring(preconditionsIdx + "*Preconditions*:".length()).trim();
+          instructionsText = "";
+        }
+      } else if (rawSteps.contains("*Steps*:")) {
+        int stepsIdx = rawSteps.indexOf("*Steps*:");
+        instructionsText = rawSteps.substring(stepsIdx + "*Steps*:".length()).trim();
+      }
+    }
+
+    TmsManualScenarioPreconditionsRQ preconditionsRQ = null;
+    if (StringUtils.isNotBlank(preconditionsText)) {
+      preconditionsRQ = TmsManualScenarioPreconditionsRQ.builder()
+          .value(preconditionsText)
+          .build();
+    }
+
+    List<TmsManualScenarioAttachmentRQ> attachmentRQs = null;
+    if (CollectionUtils.isNotEmpty(attachments)) {
+      attachmentRQs = attachments.stream()
+          .filter(att -> att.getId() != null)
+          .map(att -> TmsManualScenarioAttachmentRQ.builder()
+              .id(String.valueOf(att.getId()))
+              .build())
+          .collect(Collectors.toList());
+    }
+
+    return TmsTextManualScenarioRQ.builder()
+        .manualScenarioType(TmsManualScenarioType.TEXT)
+        .instructions(instructionsText)
+        .expectedResult(remoteTestCase.getExpectedResults())
+        .preconditions(preconditionsRQ)
+        .attachments(attachmentRQs)
+        .build();
+  }
+}

--- a/src/test/java/com/epam/reportportal/base/core/tms/sync/connector/jira/JiraHttpClientTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/sync/connector/jira/JiraHttpClientTest.java
@@ -1,0 +1,14 @@
+package com.epam.reportportal.base.core.tms.sync.connector.jira;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class JiraHttpClientTest {
+
+  @Test
+  void shouldInstantiateJiraHttpClient() {
+    JiraHttpClient client = new JiraHttpClient();
+    assertNotNull(client);
+  }
+}

--- a/src/test/java/com/epam/reportportal/base/core/tms/sync/connector/jira/QaSpaceSyncConnectorTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/sync/connector/jira/QaSpaceSyncConnectorTest.java
@@ -1,0 +1,182 @@
+package com.epam.reportportal.base.core.tms.sync.connector.jira;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.epam.reportportal.base.core.tms.enums.TmsSyncProvider;
+import com.epam.reportportal.base.core.tms.sync.dto.RemoteFolder;
+import com.epam.reportportal.base.core.tms.sync.dto.RemoteTestCase;
+import com.epam.reportportal.base.infrastructure.persistence.entity.integration.Integration;
+import com.epam.reportportal.base.infrastructure.persistence.entity.integration.IntegrationParams;
+import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class QaSpaceSyncConnectorTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Mock
+  private JiraHttpClient jiraHttpClient;
+
+  private QaSpaceSyncConnector connector;
+
+  @BeforeEach
+  void setUp() {
+    connector = new QaSpaceSyncConnector(objectMapper, jiraHttpClient);
+  }
+
+  @Test
+  void shouldReturnQaSpaceProvider() {
+    assertEquals(TmsSyncProvider.QA_SPACE, connector.getSupportedProvider());
+  }
+
+  @Test
+  void shouldValidateConfigSuccessfully() {
+    Integration integration = createIntegration("http://jira.local", "token123", "PRJ");
+    connector.validateConfig(integration);
+  }
+
+  @Test
+  void shouldThrowWhenConfigIsMissingParams() {
+    Integration integration = new Integration();
+    integration.setParams(new IntegrationParams(new HashMap<>()));
+
+    assertThrows(ReportPortalException.class, () -> connector.validateConfig(integration));
+  }
+
+  @Test
+  void shouldFetchFolderTree() {
+    Integration integration = createIntegration("http://jira.local", "token123", "PRJ");
+    String jsonResponse = """
+        {
+          "id": "1",
+          "name": "Root Folder",
+          "children": [
+            {
+              "id": "2",
+              "name": "Child Folder"
+            }
+          ]
+        }
+        """;
+
+    when(jiraHttpClient.get("http://jira.local", "token123", "rest/tm/1.0/folder/list?projectKey=PRJ&folderId=0"))
+        .thenReturn(jsonResponse);
+
+    List<RemoteFolder> folders = connector.fetchFolderTree(integration, "0");
+
+    assertNotNull(folders);
+    assertEquals(2, folders.size());
+    assertEquals("1", folders.get(0).getId());
+    assertEquals("Root Folder", folders.get(0).getName());
+    assertEquals("2", folders.get(1).getId());
+    assertEquals("Child Folder", folders.get(1).getName());
+  }
+
+  @Test
+  void shouldFetchTestCases() {
+    Integration integration = createIntegration("http://jira.local", "token123", "PRJ");
+    String folderResponse = """
+        {
+          "id": "10",
+          "name": "Folder 10",
+          "testCaseIds": ["PRJ-1", "PRJ-2"]
+        }
+        """;
+
+    when(jiraHttpClient.get("http://jira.local", "token123", "rest/tm/1.0/folder/list?projectKey=PRJ&folderId=10"))
+        .thenReturn(folderResponse);
+
+    String searchResponse = """
+        {
+          "issues": [
+            {
+              "key": "PRJ-1",
+              "fields": {
+                "summary": "TC 1",
+                "description": "Desc 1",
+                "updated": "2025-01-01T12:00:00.000+0000",
+                "customfield_19206": "*Steps*: Do test",
+                "customfield_19207": "Pass",
+                "attachment": [
+                  {
+                    "id": "100",
+                    "filename": "screenshot.png",
+                    "mimeType": "image/png",
+                    "size": 2048,
+                    "content": "http://jira.local/attachments/100"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+        """;
+
+    when(jiraHttpClient.post(eq("http://jira.local"), eq("token123"), eq("rest/api/2/search"), anyString()))
+        .thenReturn(searchResponse);
+
+    AtomicInteger totalCount = new AtomicInteger();
+    List<RemoteTestCase> fetchedTestCases = new ArrayList<>();
+
+    connector.fetchTestCases(
+        integration,
+        "10",
+        null,
+        totalCount::set,
+        fetchedTestCases::add
+    );
+
+    assertEquals(2, totalCount.get());
+    assertEquals(1, fetchedTestCases.size());
+    RemoteTestCase tc = fetchedTestCases.get(0);
+    assertEquals("PRJ-1", tc.getId());
+    assertEquals("TC 1", tc.getName());
+    assertEquals("Desc 1", tc.getDescription());
+    assertEquals(1, tc.getAttachments().size());
+    assertEquals("100", tc.getAttachments().get(0).getId());
+    assertEquals("screenshot.png", tc.getAttachments().get(0).getFilename());
+  }
+
+  @Test
+  void shouldDownloadAttachment() throws Exception {
+    Integration integration = createIntegration("http://jira.local", "token123", "PRJ");
+    InputStream stream = new ByteArrayInputStream("content".getBytes());
+
+    when(jiraHttpClient.downloadAttachmentStream("token123", "http://jira.local/att/1"))
+        .thenReturn(stream);
+
+    InputStream result = connector.downloadAttachment(integration, "http://jira.local/att/1");
+
+    assertNotNull(result);
+    verify(jiraHttpClient).downloadAttachmentStream("token123", "http://jira.local/att/1");
+  }
+
+  private Integration createIntegration(String url, String bearerPat, String projectKey) {
+    Integration integration = new Integration();
+    Map<String, Object> params = new HashMap<>();
+    params.put("url", url);
+    params.put("bearerPat", bearerPat);
+    params.put("projectKey", projectKey);
+    integration.setParams(new IntegrationParams(params));
+    return integration;
+  }
+}

--- a/src/test/java/com/epam/reportportal/base/core/tms/sync/service/TmsTestCaseSyncServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/sync/service/TmsTestCaseSyncServiceImplTest.java
@@ -1,0 +1,171 @@
+package com.epam.reportportal.base.core.tms.sync.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.epam.reportportal.base.core.tms.dto.TmsTextManualScenarioRQ;
+import com.epam.reportportal.base.core.tms.mapper.TmsTestFolderMapper;
+import com.epam.reportportal.base.core.tms.service.TmsTestCaseVersionService;
+import com.epam.reportportal.base.core.tms.sync.TmsSyncConnector;
+import com.epam.reportportal.base.core.tms.sync.dto.RemoteAttachment;
+import com.epam.reportportal.base.core.tms.sync.dto.RemoteTestCase;
+import com.epam.reportportal.base.infrastructure.persistence.binary.tms.TmsAttachmentDataStoreService;
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsAttachmentRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsSyncJobRepository;
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestCaseRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.integration.Integration;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsAttachment;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsSyncJob;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestCase;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestFolder;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.sync.SyncCounters;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.sync.SyncErrorLog;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+
+@ExtendWith(MockitoExtension.class)
+class TmsTestCaseSyncServiceImplTest {
+
+  @Mock
+  private TmsTestCaseRepository tmsTestCaseRepository;
+
+  @Mock
+  private TmsTestCaseVersionService tmsTestCaseVersionService;
+
+  @Mock
+  private TmsAttachmentDataStoreService tmsAttachmentDataStoreService;
+
+  @Mock
+  private TmsAttachmentRepository tmsAttachmentRepository;
+
+  @Mock
+  private TmsSyncJobRepository tmsSyncJobRepository;
+
+  @Mock
+  private TmsTestFolderMapper tmsTestFolderMapper;
+
+  @Mock
+  private PlatformTransactionManager transactionManager;
+
+  @Mock
+  private TmsSyncConnector<Integration> connector;
+
+  private TmsTestCaseSyncServiceImpl sut;
+
+  @BeforeEach
+  void setUp() {
+    TransactionStatus transactionStatus = mock(TransactionStatus.class);
+    when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
+
+    sut = new TmsTestCaseSyncServiceImpl(
+        tmsTestCaseRepository,
+        tmsTestCaseVersionService,
+        tmsAttachmentDataStoreService,
+        tmsAttachmentRepository,
+        tmsSyncJobRepository,
+        tmsTestFolderMapper,
+        transactionManager
+    );
+  }
+
+  @Test
+  void shouldProcessTestCaseBatchAndLinkAttachments() {
+    Long jobId = 10L;
+    Long projectId = 1L;
+    Long localFolderId = 5L;
+
+    Integration integration = new Integration();
+    integration.setId(20L);
+
+    RemoteAttachment remoteAttachment = RemoteAttachment.builder()
+        .id("att-1")
+        .filename("image.png")
+        .mimeType("image/png")
+        .size(1024L)
+        .contentUrl("http://jira/attachments/1")
+        .build();
+
+    RemoteTestCase remoteTestCase = RemoteTestCase.builder()
+        .id("KEY-101")
+        .name("Test Scenario")
+        .description("Description")
+        .steps("*Preconditions*: Some preconditions\n*Steps*: Step 1 instruction")
+        .expectedResults("Expected outcome")
+        .updatedAt(Instant.now())
+        .attachments(List.of(remoteAttachment))
+        .build();
+
+    when(tmsTestCaseRepository.findByProjectIdAndExternalIdIn(projectId, List.of("KEY-101")))
+        .thenReturn(Collections.emptyList());
+
+    InputStream inputStream = new ByteArrayInputStream("file content".getBytes());
+    when(connector.downloadAttachment(eq(integration), eq("http://jira/attachments/1")))
+        .thenReturn(inputStream);
+    when(tmsAttachmentDataStoreService.save(any(), any())).thenReturn("datastore-file-id-1");
+
+    TmsTestFolder folder = new TmsTestFolder();
+    folder.setId(localFolderId);
+    when(tmsTestFolderMapper.convertFromId(localFolderId)).thenReturn(folder);
+
+    when(tmsTestCaseRepository.saveAll(anyList())).thenAnswer(invocation -> {
+      List<TmsTestCase> cases = invocation.getArgument(0);
+      cases.get(0).setId(100L);
+      return cases;
+    });
+
+    when(tmsAttachmentRepository.saveAll(anyList())).thenAnswer(invocation -> {
+      List<TmsAttachment> attachments = invocation.getArgument(0);
+      attachments.get(0).setId(555L);
+      return attachments;
+    });
+
+    TmsSyncJob job = new TmsSyncJob();
+    job.setId(jobId);
+    job.setCounters(new SyncCounters(0, 0, 0));
+    job.setErrorLog(new SyncErrorLog(new ArrayList<>()));
+    when(tmsSyncJobRepository.findById(jobId)).thenReturn(Optional.of(job));
+    when(tmsSyncJobRepository.save(any(TmsSyncJob.class))).thenReturn(job);
+
+    sut.processTestCaseBatch(jobId, projectId, connector, integration, List.of(remoteTestCase), localFolderId);
+
+    ArgumentCaptor<TmsTextManualScenarioRQ> scenarioCaptor =
+        ArgumentCaptor.forClass(TmsTextManualScenarioRQ.class);
+    verify(tmsTestCaseVersionService).createDefaultTestCaseVersion(
+        eq(projectId), any(TmsTestCase.class), scenarioCaptor.capture());
+
+    TmsTextManualScenarioRQ capturedScenario = scenarioCaptor.getValue();
+    assertNotNull(capturedScenario);
+    assertEquals("Step 1 instruction", capturedScenario.getInstructions());
+    assertEquals("Expected outcome", capturedScenario.getExpectedResult());
+    assertNotNull(capturedScenario.getPreconditions());
+    assertEquals("Some preconditions", capturedScenario.getPreconditions().getValue());
+    assertNotNull(capturedScenario.getAttachments());
+    assertEquals(1, capturedScenario.getAttachments().size());
+    assertEquals("555", capturedScenario.getAttachments().get(0).getId());
+
+    verify(tmsAttachmentRepository, times(1)).saveAll(anyList());
+    assertEquals(1, job.getCounters().getProcessed());
+    assertEquals(0, job.getCounters().getFailed());
+  }
+}


### PR DESCRIPTION
### Changes Made:
1. **Link TMS Test Case Manual Scenario with Attachments:**
   - Updated `TmsTestCaseSyncServiceImpl` to maintain per-test-case attachment tracking during sync batch processing.
   - Attachments are persisted to `tms_attachment` first within the transaction to obtain database IDs.
   - Linked attachment IDs into `TmsTextManualScenarioRQ.attachments`, ensuring `TmsTextManualScenarioAttachmentService` populates the join table `tms_text_manual_scenario_attachment` and clears TTL on associated attachments.

2. **Make `JiraHttpClient` a Spring Component Singleton:**
   - Annotated `JiraHttpClient` with `@Component` and made it stateless by passing Jira base URL and bearer token to `get()`, `post()`, and `downloadAttachmentStream()`.
   - Reuses a single connection-pooled `CloseableHttpClient` rather than re-instantiating HTTP clients on every remote call and attachment download.
   - Injected singleton `JiraHttpClient` into `QaSpaceSyncConnector`.

3. **Added Unit Tests:**
   - `TmsTestCaseSyncServiceImplTest`
   - `QaSpaceSyncConnectorTest`
   - `JiraHttpClientTest`