### PR TITLE
fix(tms): publish test case created activity event on test case duplication (EPMRPP-118812)

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/tms/controller/TestCaseController.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/controller/TestCaseController.java
@@ -409,10 +409,11 @@ public class TestCaseController {
   public BatchDuplicateTestCasesRS duplicateTestCases(@PathVariable("projectKey") String projectKey,
       @Valid @RequestBody BatchDuplicateTestCasesRQ duplicateRequest,
       @AuthenticationPrincipal ReportPortalUser user) {
+    var membershipDetails = projectExtractor
+        .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey));
     return tmsTestCaseService.duplicate(
-        projectExtractor
-            .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey))
-            .getProjectId(),
+        membershipDetails,
+        user,
         duplicateRequest
     );
   }

--- a/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsMilestoneController.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsMilestoneController.java
@@ -227,9 +227,8 @@ public class TmsMilestoneController {
       @PathVariable("id") Long milestoneId,
       @Valid @RequestBody TmsMilestoneRQ duplicateMilestoneRQ,
       @AuthenticationPrincipal ReportPortalUser user) {
-    var projectId = projectExtractor
-        .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey))
-        .getProjectId();
-    return tmsMilestoneService.duplicate(projectId, milestoneId, duplicateMilestoneRQ);
+    var membershipDetails = projectExtractor
+        .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey));
+    return tmsMilestoneService.duplicate(membershipDetails, user, milestoneId, duplicateMilestoneRQ);
   }
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsTestFolderController.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsTestFolderController.java
@@ -332,10 +332,11 @@ public class TmsTestFolderController {
       @Parameter(description = "Duplicated folder details", required = true)
       @RequestBody final TmsTestFolderRQ inputDto,
       @AuthenticationPrincipal ReportPortalUser user) {
+    var membershipDetails = projectExtractor
+        .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey));
     return tmsTestFolderService.duplicateFolder(
-        projectExtractor
-            .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey))
-            .getProjectId(),
+        membershipDetails,
+        user,
         folderId,
         inputDto
     );

--- a/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsTestPlanController.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsTestPlanController.java
@@ -313,10 +313,11 @@ public class TmsTestPlanController {
       @PathVariable("id") Long testPlanId,
       @RequestBody TmsTestPlanRQ duplicateTestPlanRQ,
       @AuthenticationPrincipal ReportPortalUser user) {
+    var membershipDetails = projectExtractor
+        .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey));
     return tmsTestPlanService.duplicate(
-        projectExtractor
-            .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey))
-            .getProjectId(),
+        membershipDetails,
+        user,
         testPlanId,
         duplicateTestPlanRQ);
   }

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneService.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneService.java
@@ -3,7 +3,9 @@ package com.epam.reportportal.base.core.tms.service;
 import com.epam.reportportal.base.core.tms.dto.DuplicateTmsMilestoneRS;
 import com.epam.reportportal.base.core.tms.dto.TmsMilestoneRQ;
 import com.epam.reportportal.base.core.tms.dto.TmsMilestoneRS;
+import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Filter;
+import com.epam.reportportal.base.infrastructure.persistence.entity.organization.MembershipDetails;
 import com.epam.reportportal.base.model.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -79,10 +81,12 @@ public interface TmsMilestoneService {
   /**
    * Duplicates an existing milestone.
    *
-   * @param projectId            the project ID
+   * @param membershipDetails    the membership details of user
+   * @param user                 the authenticated user
    * @param milestoneId          the milestone ID to duplicate
    * @param duplicateMilestoneRQ the duplicate milestone request data
    * @return duplicated milestone details
    */
-  DuplicateTmsMilestoneRS duplicate(Long projectId, Long milestoneId, TmsMilestoneRQ duplicateMilestoneRQ);
+  DuplicateTmsMilestoneRS duplicate(MembershipDetails membershipDetails, ReportPortalUser user,
+      Long milestoneId, TmsMilestoneRQ duplicateMilestoneRQ);
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImpl.java
@@ -4,9 +4,11 @@ import com.epam.reportportal.base.core.tms.dto.DuplicateTmsMilestoneRS;
 import com.epam.reportportal.base.core.tms.dto.TmsMilestoneRQ;
 import com.epam.reportportal.base.core.tms.dto.TmsMilestoneRS;
 import com.epam.reportportal.base.core.tms.mapper.TmsMilestoneMapper;
+import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Filter;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsMilestoneRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.filterable.TmsMilestoneFilterableRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.organization.MembershipDetails;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsMilestone;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
@@ -163,8 +165,10 @@ public class TmsMilestoneServiceImpl implements TmsMilestoneService {
 
   @Override
   @Transactional
-  public DuplicateTmsMilestoneRS duplicate(Long projectId, Long milestoneId,
+  public DuplicateTmsMilestoneRS duplicate(MembershipDetails membershipDetails,
+      ReportPortalUser user, Long milestoneId,
       TmsMilestoneRQ duplicateMilestoneRQ) {
+    var projectId = membershipDetails.getProjectId();
     // Verify an original milestone exists
     var originalMilestone = findMilestoneByIdAndProjectId(projectId, milestoneId);
 
@@ -174,7 +178,7 @@ public class TmsMilestoneServiceImpl implements TmsMilestoneService {
     var savedMilestone = tmsMilestoneRepository.save(newMilestone);
 
     var duplicateTestPlansRS = tmsTestPlanService.duplicateTestPlansInMilestone(
-        projectId, milestoneId, savedMilestone.getId()
+        membershipDetails, user, milestoneId, savedMilestone.getId()
     );
 
     return tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseService.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseService.java
@@ -101,16 +101,19 @@ public interface TmsTestCaseService {
   /**
    * Duplicates multiple test cases with all their related data.
    *
-   * @param projectId        The ID of the project.
+   * @param membershipDetails The membership details.
+   * @param user The report portal user.
    * @param duplicateRequest Request containing test case IDs to duplicate.
    * @return A list of data transfer objects containing details of the duplicated test cases.
    */
-  BatchDuplicateTestCasesRS duplicate(long projectId, BatchDuplicateTestCasesRQ duplicateRequest);
+  BatchDuplicateTestCasesRS duplicate(MembershipDetails membershipDetails, ReportPortalUser user,
+      BatchDuplicateTestCasesRQ duplicateRequest);
 
-  BatchTestCaseOperationResultRS duplicateTestCases(long projectId, List<Long> originalTestCaseIds);
-
-  BatchTestCaseOperationResultRS duplicateTestCases(long projectId, TmsTestFolder targetFolder,
+  BatchTestCaseOperationResultRS duplicateTestCases(MembershipDetails membershipDetails, ReportPortalUser user,
       List<Long> originalTestCaseIds);
+
+  BatchTestCaseOperationResultRS duplicateTestCases(MembershipDetails membershipDetails, ReportPortalUser user,
+      TmsTestFolder targetFolder, List<Long> originalTestCaseIds);
 
   /**
    * Retrieves test cases added to a test plan with pagination. Returns test cases with last execution only (without

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseServiceImpl.java
@@ -38,6 +38,7 @@ import com.epam.reportportal.base.infrastructure.persistence.dao.tms.filterable.
 import com.epam.reportportal.base.infrastructure.persistence.entity.organization.MembershipDetails;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestCase;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestCaseExecution;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestCaseVersion;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestFolder;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
@@ -168,12 +169,7 @@ public class TmsTestCaseServiceImpl implements TmsTestCaseService {
         tmsTestCase,
         tmsTestCaseRQ.getManualScenario());
 
-    var after = tmsTestCaseActivityResourceMapper.buildActivityResource(tmsTestCase,
-        defaultVersion);
-
-    eventPublisher.publishEvent(
-        tmsTestCaseActivityResourceMapper.buildTestCaseCreatedEvent(membershipDetails, user, after)
-    );
+    publishTestCaseCreatedEvent(membershipDetails, user, tmsTestCase, defaultVersion);
 
     return tmsTestCaseMapper.convert(tmsTestCase, defaultVersion);
   }
@@ -703,8 +699,10 @@ public class TmsTestCaseServiceImpl implements TmsTestCaseService {
 
   @Override
   @Transactional
-  public BatchDuplicateTestCasesRS duplicate(long projectId,
+  public BatchDuplicateTestCasesRS duplicate(MembershipDetails membershipDetails,
+      ReportPortalUser user,
       BatchDuplicateTestCasesRQ duplicateRequest) {
+    var projectId = membershipDetails.getProjectId();
     validateTestCasesExist(projectId, duplicateRequest.getTestCaseIds());
 
     var targetFolderId = tmsTestFolderService.resolveTargetFolderId(
@@ -716,7 +714,7 @@ public class TmsTestCaseServiceImpl implements TmsTestCaseService {
     var duplicatedTestCases = duplicateRequest
         .getTestCaseIds()
         .stream()
-        .map(testCaseId -> duplicateTestCase(projectId, testCaseId, targetFolderId))
+        .map(testCaseId -> duplicateTestCase(membershipDetails, user, projectId, testCaseId, targetFolderId))
         .toList();
     return BatchDuplicateTestCasesRS.builder()
         .testFolderId(targetFolderId)
@@ -726,77 +724,24 @@ public class TmsTestCaseServiceImpl implements TmsTestCaseService {
 
   @Override
   @Transactional
-  public BatchTestCaseOperationResultRS duplicateTestCases(long projectId, List<Long> testCaseIds) {
-    var errors = new ArrayList<BatchTestCaseOperationError>();
-    var successfulIds = new ArrayList<Long>();
-
-    for (var testCaseId : testCaseIds) {
-      try {
-        var originalTestCase = tmsTestCaseRepository
-            .findByProjectIdAndId(projectId, testCaseId)
-            .orElseThrow(() -> new ReportPortalException(
-                NOT_FOUND, TEST_CASE_NOT_FOUND_BY_ID.formatted(testCaseId, projectId))
-            );
-
-        var originalDefaultVersion = tmsTestCaseVersionService.getDefaultVersion(testCaseId);
-
-        var duplicatedTestCase = tmsTestCaseMapper.duplicateTestCase(
-            originalTestCase, originalTestCase.getTestFolder()
-        );
-
-        duplicatedTestCase = tmsTestCaseRepository.save(duplicatedTestCase);
-
-        tmsTestCaseVersionService.duplicateDefaultVersion(duplicatedTestCase,
-            originalDefaultVersion);
-
-        if (CollectionUtils.isNotEmpty(originalTestCase.getAttributes())) {
-          tmsTestCaseAttributeService.duplicateTestCaseAttributes(originalTestCase,
-              duplicatedTestCase);
-        }
-
-        successfulIds.add(duplicatedTestCase.getId());
-
-      } catch (Exception e) {
-        errors.add(new BatchTestCaseOperationError(testCaseId,
-            "Failed to duplicate test case: " + e.getMessage()));
-      }
-    }
-
-    return tmsTestCaseMapper.toBatchOperationResult(successfulIds, errors);
+  public BatchTestCaseOperationResultRS duplicateTestCases(MembershipDetails membershipDetails,
+      ReportPortalUser user, List<Long> testCaseIds) {
+    return duplicateTestCases(membershipDetails, user, null, testCaseIds);
   }
 
   @Override
-  public BatchTestCaseOperationResultRS duplicateTestCases(long projectId,
-      TmsTestFolder targetFolder, List<Long> testCaseIds) {
+  @Transactional
+  public BatchTestCaseOperationResultRS duplicateTestCases(MembershipDetails membershipDetails,
+      ReportPortalUser user, TmsTestFolder targetFolder, List<Long> testCaseIds) {
     var errors = new ArrayList<BatchTestCaseOperationError>();
     var successfulIds = new ArrayList<Long>();
+    var projectId = membershipDetails.getProjectId();
 
     for (var testCaseId : testCaseIds) {
       try {
-        var originalTestCase = tmsTestCaseRepository
-            .findByProjectIdAndId(projectId, testCaseId)
-            .orElseThrow(() -> new ReportPortalException(
-                NOT_FOUND, TEST_CASE_NOT_FOUND_BY_ID.formatted(testCaseId, projectId))
-            );
-
-        var originalDefaultVersion = tmsTestCaseVersionService.getDefaultVersion(testCaseId);
-
-        var duplicatedTestCase = tmsTestCaseMapper.duplicateTestCase(
-            originalTestCase, targetFolder
-        );
-
-        duplicatedTestCase = tmsTestCaseRepository.save(duplicatedTestCase);
-
-        tmsTestCaseVersionService.duplicateDefaultVersion(duplicatedTestCase,
-            originalDefaultVersion);
-
-        if (CollectionUtils.isNotEmpty(originalTestCase.getAttributes())) {
-          tmsTestCaseAttributeService.duplicateTestCaseAttributes(originalTestCase,
-              duplicatedTestCase);
-        }
-
-        successfulIds.add(duplicatedTestCase.getId());
-
+        var duplicated = duplicateTestCaseInternal(membershipDetails, user, projectId,
+            testCaseId, targetFolder);
+        successfulIds.add(duplicated.testCase().getId());
       } catch (Exception e) {
         errors.add(new BatchTestCaseOperationError(testCaseId,
             "Failed to duplicate test case: " + e.getMessage()));
@@ -826,7 +771,19 @@ public class TmsTestCaseServiceImpl implements TmsTestCaseService {
   }
 
   @Transactional
-  public TmsTestCaseRS duplicateTestCase(long projectId, Long testCaseId, Long targetFolderId) {
+  public TmsTestCaseRS duplicateTestCase(MembershipDetails membershipDetails,
+      ReportPortalUser user, long projectId, Long testCaseId, Long targetFolderId) {
+    var targetFolder = targetFolderId != null
+        ? tmsTestFolderService.getEntityById(projectId, targetFolderId)
+        : null;
+    var duplicated = duplicateTestCaseInternal(membershipDetails, user, projectId, testCaseId, targetFolder);
+    return tmsTestCaseMapper.convert(duplicated.testCase(), duplicated.defaultVersion());
+  }
+
+  private record DuplicatedTestCase(TmsTestCase testCase, TmsTestCaseVersion defaultVersion) {}
+
+  private DuplicatedTestCase duplicateTestCaseInternal(MembershipDetails membershipDetails,
+      ReportPortalUser user, long projectId, Long testCaseId, TmsTestFolder targetFolder) {
     var originalTestCase = tmsTestCaseRepository
         .findByProjectIdAndId(projectId, testCaseId)
         .orElseThrow(() -> new ReportPortalException(
@@ -835,9 +792,9 @@ public class TmsTestCaseServiceImpl implements TmsTestCaseService {
 
     var originalDefaultVersion = tmsTestCaseVersionService.getDefaultVersion(testCaseId);
 
-    var targetFolder = tmsTestFolderService.getEntityById(projectId, targetFolderId);
+    var folderToUse = targetFolder != null ? targetFolder : originalTestCase.getTestFolder();
 
-    var duplicatedTestCase = tmsTestCaseMapper.duplicateTestCase(originalTestCase, targetFolder);
+    var duplicatedTestCase = tmsTestCaseMapper.duplicateTestCase(originalTestCase, folderToUse);
 
     duplicatedTestCase = tmsTestCaseRepository.save(duplicatedTestCase);
 
@@ -848,8 +805,21 @@ public class TmsTestCaseServiceImpl implements TmsTestCaseService {
       tmsTestCaseAttributeService.duplicateTestCaseAttributes(originalTestCase, duplicatedTestCase);
     }
 
-    return tmsTestCaseMapper.convert(duplicatedTestCase, duplicatedDefaultVersion);
+    publishTestCaseCreatedEvent(membershipDetails, user, duplicatedTestCase, duplicatedDefaultVersion);
+
+    return new DuplicatedTestCase(duplicatedTestCase, duplicatedDefaultVersion);
   }
+
+  private void publishTestCaseCreatedEvent(MembershipDetails membershipDetails,
+      ReportPortalUser user, TmsTestCase testCase, TmsTestCaseVersion version) {
+    if (membershipDetails != null && user != null) {
+      var after = tmsTestCaseActivityResourceMapper.buildActivityResource(testCase, version);
+      eventPublisher.publishEvent(
+          tmsTestCaseActivityResourceMapper.buildTestCaseCreatedEvent(membershipDetails, user, after)
+      );
+    }
+  }
+
 
   @Override
   @Transactional(readOnly = true)

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestFolderService.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestFolderService.java
@@ -106,12 +106,14 @@ public interface TmsTestFolderService {
   /**
    * Duplicates a test folder with all its subfolders and test cases.
    *
-   * @param projectId The ID of the project.
-   * @param folderId  The ID of the folder to duplicate.
-   * @param inputDto  The request containing name and parent folder information.
+   * @param membershipDetails The membership details of user.
+   * @param user              The authenticated user.
+   * @param folderId          The ID of the folder to duplicate.
+   * @param inputDto          The request containing name and parent folder information.
    * @return The duplicated folder details with duplication statistics.
    */
-  DuplicateTmsTestFolderRS duplicateFolder(long projectId, Long folderId, TmsTestFolderRQ inputDto);
+  DuplicateTmsTestFolderRS duplicateFolder(MembershipDetails membershipDetails, ReportPortalUser user,
+      Long folderId, TmsTestFolderRQ inputDto);
 
   /**
    * Retrieves test folders by test plan ID with pagination.

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestFolderServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestFolderServiceImpl.java
@@ -402,9 +402,10 @@ public class TmsTestFolderServiceImpl implements TmsTestFolderService {
 
   @Override
   @Transactional
-  public DuplicateTmsTestFolderRS duplicateFolder(long projectId, Long folderId,
-      TmsTestFolderRQ inputDto) {
+  public DuplicateTmsTestFolderRS duplicateFolder(MembershipDetails membershipDetails,
+      ReportPortalUser user, Long folderId, TmsTestFolderRQ inputDto) {
 
+    var projectId = membershipDetails.getProjectId();
     var sourceFolder = findFolderWithFullHierarchy(projectId, folderId);
     var targetParentFolderId = resolveTargetParentForDuplication(projectId, inputDto);
 
@@ -412,7 +413,8 @@ public class TmsTestFolderServiceImpl implements TmsTestFolderService {
     var testCaseStatistics = new TestCaseDuplicationStatistics();
 
     var duplicatedRootFolder = duplicateFolderHierarchy(
-        projectId,
+        membershipDetails,
+        user,
         sourceFolder,
         inputDto.getName(),
         targetParentFolderId,
@@ -752,7 +754,8 @@ public class TmsTestFolderServiceImpl implements TmsTestFolderService {
    * @return The duplicated folder entity
    */
   private TmsTestFolder duplicateFolderHierarchy(
-      long projectId,
+      MembershipDetails membershipDetails,
+      ReportPortalUser user,
       TmsTestFolder sourceFolder,
       String targetName,
       Long targetParentFolderId,
@@ -761,6 +764,7 @@ public class TmsTestFolderServiceImpl implements TmsTestFolderService {
       TestCaseDuplicationStatistics testCaseStatistics) {
 
     try {
+      var projectId = membershipDetails.getProjectId();
       TmsTestFolder targetParentFolder = null;
       if (nonNull(targetParentFolderId)) {
         targetParentFolder = getEntityById(projectId, targetParentFolderId);
@@ -788,7 +792,8 @@ public class TmsTestFolderServiceImpl implements TmsTestFolderService {
       folderStatistics.addSuccess(duplicatedFolder.getId());
 
       duplicateTestCasesInFolder(
-          projectId,
+          membershipDetails,
+          user,
           sourceFolder,
           duplicatedFolder,
           testCaseStatistics
@@ -798,7 +803,8 @@ public class TmsTestFolderServiceImpl implements TmsTestFolderService {
         for (var subFolder : sourceFolder.getSubFolders()) {
           try {
             var duplicatedSubFolder = duplicateFolderHierarchy(
-                projectId,
+                membershipDetails,
+                user,
                 subFolder,
                 subFolder.getName() + "-copy",
                 duplicatedFolder.getId(),
@@ -836,7 +842,8 @@ public class TmsTestFolderServiceImpl implements TmsTestFolderService {
   }
 
   private void duplicateTestCasesInFolder(
-      long projectId,
+      MembershipDetails membershipDetails,
+      ReportPortalUser user,
       TmsTestFolder sourceFolder,
       TmsTestFolder targetFolder,
       TestCaseDuplicationStatistics testCaseStatistics) {
@@ -849,7 +856,7 @@ public class TmsTestFolderServiceImpl implements TmsTestFolderService {
 
     try {
       var duplicateTestCasesResult = tmsTestCaseService.duplicateTestCases(
-          projectId, targetFolder, testCaseIds
+          membershipDetails, user, targetFolder, testCaseIds
       );
 
       testCaseStatistics.merge(duplicateTestCasesResult);

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanService.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanService.java
@@ -7,7 +7,9 @@ import com.epam.reportportal.base.core.tms.dto.TmsTestFolderRS;
 import com.epam.reportportal.base.core.tms.dto.TmsTestPlanRQ;
 import com.epam.reportportal.base.core.tms.dto.TmsTestPlanRS;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchTestCaseOperationResultRS;
+import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Filter;
+import com.epam.reportportal.base.infrastructure.persistence.entity.organization.MembershipDetails;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestPlan;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import com.epam.reportportal.base.model.Page;
@@ -29,10 +31,10 @@ public interface TmsTestPlanService extends CrudService<TmsTestPlanRQ, TmsTestPl
 
   boolean removeSingleTestCaseFromPlan(Long testPlanId, Long testCaseId);
 
-  DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId,
+  DuplicateTmsTestPlanRS duplicate(MembershipDetails membershipDetails, ReportPortalUser user, Long testPlanId,
       TmsTestPlanRQ duplicateTestPlanRQ);
 
-  DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId, Long targetMilestoneId);
+  DuplicateTmsTestPlanRS duplicate(MembershipDetails membershipDetails, ReportPortalUser user, Long testPlanId, Long targetMilestoneId);
 
   /**
    * Retrieves test cases added to a test plan with pagination. Returns test cases with last execution only (without
@@ -95,7 +97,7 @@ public interface TmsTestPlanService extends CrudService<TmsTestPlanRQ, TmsTestPl
 
   List<TmsTestPlanRS> getByMilestoneId(Long projectId, Long milestoneId);
 
-  List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(Long projectId, Long sourceMilestoneId, Long targetMilestoneId);
+  List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(MembershipDetails membershipDetails, ReportPortalUser user, Long sourceMilestoneId, Long targetMilestoneId);
 
   void addTestPlanMilestone(Long projectId, Long milestoneId, Long testPlanId);
 

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImpl.java
@@ -11,7 +11,9 @@ import com.epam.reportportal.base.core.tms.dto.TmsTestPlanRS;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchTestCaseOperationError;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchTestCaseOperationResultRS;
 import com.epam.reportportal.base.core.tms.mapper.TmsTestPlanMapper;
+import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Filter;
+import com.epam.reportportal.base.infrastructure.persistence.entity.organization.MembershipDetails;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestPlanRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestPlanTestCaseRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.filterable.TmsTestPlanFilterableRepository;
@@ -266,8 +268,10 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
 
   @Override
   @Transactional
-  public DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId,
+  public DuplicateTmsTestPlanRS duplicate(MembershipDetails membershipDetails,
+      ReportPortalUser user, Long testPlanId,
       TmsTestPlanRQ duplicateTestPlanRQ) {
+    var projectId = membershipDetails.getProjectId();
     // Get original test plan
     var originalTestPlan = testPlanRepository
         .findByIdAndProjectId(testPlanId, projectId)
@@ -291,7 +295,8 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
         originalTestPlan.getId());
 
     // Process test case duplication and addition to plan
-    var duplicateTestCasesStatistic = processBatchTestCaseDuplication(projectId,
+    var duplicateTestCasesStatistic = processBatchTestCaseDuplication(membershipDetails,
+        user,
         duplicatedTestPlan.getId(),
         originalTestCaseIds);
 
@@ -301,7 +306,9 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
 
   @Override
   @Transactional
-  public DuplicateTmsTestPlanRS duplicate(Long projectId, Long testPlanId, Long targetMilestoneId) {
+  public DuplicateTmsTestPlanRS duplicate(MembershipDetails membershipDetails,
+      ReportPortalUser user, Long testPlanId, Long targetMilestoneId) {
+    var projectId = membershipDetails.getProjectId();
     // Get original test plan
     var originalTestPlan = testPlanRepository
         .findByIdAndProjectId(testPlanId, projectId)
@@ -322,7 +329,8 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
         originalTestPlan.getId());
 
     // Process test case duplication and addition to plan
-    var duplicateTestCasesStatistic = processBatchTestCaseDuplication(projectId,
+    var duplicateTestCasesStatistic = processBatchTestCaseDuplication(membershipDetails,
+        user,
         duplicatedTestPlan.getId(),
         originalTestCaseIds);
 
@@ -473,8 +481,9 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
 
   @Override
   @Transactional
-  public List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(Long projectId,
-      Long sourceMilestoneId, Long targetMilestoneId) {
+  public List<DuplicateTmsTestPlanRS> duplicateTestPlansInMilestone(MembershipDetails membershipDetails,
+      ReportPortalUser user, Long sourceMilestoneId, Long targetMilestoneId) {
+    var projectId = membershipDetails.getProjectId();
     var testPlanIds = testPlanRepository.findIdsByProjectIdAndMilestoneId(
         projectId, sourceMilestoneId
     );
@@ -484,7 +493,7 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
     }
     var result = new ArrayList<DuplicateTmsTestPlanRS>();
     for (var testPlanId : testPlanIds) {
-      var duplicatedTestPlanRS = duplicate(projectId, testPlanId, targetMilestoneId);
+      var duplicatedTestPlanRS = duplicate(membershipDetails, user, testPlanId, targetMilestoneId);
       result.add(duplicatedTestPlanRS);
     }
     return result;
@@ -505,7 +514,8 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
     testPlanRepository.removeTestPlansFromMilestone(milestoneId, projectId);
   }
 
-  private BatchTestCaseOperationResultRS processBatchTestCaseDuplication(long projectId,
+  private BatchTestCaseOperationResultRS processBatchTestCaseDuplication(MembershipDetails membershipDetails,
+      ReportPortalUser user,
       Long newTestPlanId,
       List<Long> originalTestCaseIds) {
     if (originalTestCaseIds.isEmpty()) {
@@ -513,8 +523,10 @@ public class TmsTestPlanServiceImpl implements TmsTestPlanService {
           "No test cases to duplicate");
     }
 
+    var projectId = membershipDetails.getProjectId();
+
     // Step 1: Duplicate test cases in batch
-    var duplicationResult = tmsTestCaseService.duplicateTestCases(projectId, originalTestCaseIds);
+    var duplicationResult = tmsTestCaseService.duplicateTestCases(membershipDetails, user, originalTestCaseIds);
 
     // Step 2: Add successfully duplicated test cases to the new plan
     if (!duplicationResult.getSuccessTestCaseIds().isEmpty()) {

--- a/src/test/java/com/epam/reportportal/base/core/tms/controller/unit/TmsTestCaseControllerTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/controller/unit/TmsTestCaseControllerTest.java
@@ -1008,7 +1008,7 @@ public class TmsTestCaseControllerTest {
         .testFolderId(5L)
         .testCases(List.of(new TmsTestCaseRS(), new TmsTestCaseRS(), new TmsTestCaseRS()))
         .build();
-    given(tmsTestCaseService.duplicate(projectId, duplicateRequest)).willReturn(duplicateResponse);
+    given(tmsTestCaseService.duplicate(membershipDetails, testUser, duplicateRequest)).willReturn(duplicateResponse);
 
     mockMvc.perform(
             post("/v1/project/{projectKey}/tms/test-case/batch/duplicate", projectKey)
@@ -1017,7 +1017,7 @@ public class TmsTestCaseControllerTest {
         .andExpect(status().isOk());
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestCaseService).duplicate(projectId, duplicateRequest);
+    verify(tmsTestCaseService).duplicate(membershipDetails, testUser, duplicateRequest);
   }
 
   @Test
@@ -1030,7 +1030,7 @@ public class TmsTestCaseControllerTest {
         .testFolderId(5L)
         .testCases(List.of(new TmsTestCaseRS()))
         .build();
-    given(tmsTestCaseService.duplicate(projectId, duplicateRequest)).willReturn(duplicateResponse);
+    given(tmsTestCaseService.duplicate(membershipDetails, testUser, duplicateRequest)).willReturn(duplicateResponse);
 
     mockMvc.perform(
             post("/v1/project/{projectKey}/tms/test-case/batch/duplicate", projectKey)
@@ -1039,7 +1039,7 @@ public class TmsTestCaseControllerTest {
         .andExpect(status().isOk());
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestCaseService).duplicate(projectId, duplicateRequest);
+    verify(tmsTestCaseService).duplicate(membershipDetails, testUser, duplicateRequest);
   }
 
   @Test
@@ -1054,7 +1054,7 @@ public class TmsTestCaseControllerTest {
             new TmsTestCaseRS(), new TmsTestCaseRS(), new TmsTestCaseRS(),
             new TmsTestCaseRS(), new TmsTestCaseRS()))
         .build();
-    given(tmsTestCaseService.duplicate(projectId, duplicateRequest)).willReturn(duplicateResponse);
+    given(tmsTestCaseService.duplicate(membershipDetails, testUser, duplicateRequest)).willReturn(duplicateResponse);
 
     mockMvc.perform(
             post("/v1/project/{projectKey}/tms/test-case/batch/duplicate", projectKey)
@@ -1063,7 +1063,7 @@ public class TmsTestCaseControllerTest {
         .andExpect(status().isOk());
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestCaseService).duplicate(projectId, duplicateRequest);
+    verify(tmsTestCaseService).duplicate(membershipDetails, testUser, duplicateRequest);
   }
 
   @Test
@@ -1079,7 +1079,7 @@ public class TmsTestCaseControllerTest {
         .testFolderId(15L)
         .testCases(List.of(new TmsTestCaseRS(), new TmsTestCaseRS()))
         .build();
-    given(tmsTestCaseService.duplicate(projectId, duplicateRequest)).willReturn(duplicateResponse);
+    given(tmsTestCaseService.duplicate(membershipDetails, testUser, duplicateRequest)).willReturn(duplicateResponse);
 
     mockMvc.perform(
             post("/v1/project/{projectKey}/tms/test-case/batch/duplicate", projectKey)
@@ -1088,7 +1088,7 @@ public class TmsTestCaseControllerTest {
         .andExpect(status().isOk());
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestCaseService).duplicate(projectId, duplicateRequest);
+    verify(tmsTestCaseService).duplicate(membershipDetails, testUser, duplicateRequest);
   }
 
   @Test
@@ -1103,6 +1103,6 @@ public class TmsTestCaseControllerTest {
                 .content(objectMapper.writeValueAsString(duplicateRequest)))
         .andExpect(status().isBadRequest());
 
-    verify(tmsTestCaseService, never()).duplicate(projectId, duplicateRequest);
+    verify(tmsTestCaseService, never()).duplicate(eq(membershipDetails), eq(testUser), any());
   }
 }

--- a/src/test/java/com/epam/reportportal/base/core/tms/controller/unit/TmsTestFolderControllerTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/controller/unit/TmsTestFolderControllerTest.java
@@ -74,6 +74,7 @@ public class TmsTestFolderControllerTest {
 
   private MockMvc mockMvc;
   private ReportPortalUser testUser;
+  private MembershipDetails membershipDetails;
   private ObjectMapper objectMapper;
 
   @BeforeEach
@@ -125,7 +126,7 @@ public class TmsTestFolderControllerTest {
         .build();
 
     // Setup the project extractor mock to return a MembershipDetails with the projectId
-    MembershipDetails membershipDetails = MembershipDetails.builder()
+    membershipDetails = MembershipDetails.builder()
         .withProjectId(projectId)
         .withProjectKey(projectKey)
         .build();
@@ -770,7 +771,7 @@ public class TmsTestFolderControllerTest {
 
     String jsonContent = objectMapper.writeValueAsString(request);
 
-    given(tmsTestFolderService.duplicateFolder(projectId, folderId, request))
+    given(tmsTestFolderService.duplicateFolder(membershipDetails, testUser, folderId, request))
         .willReturn(expectedResponse);
 
     mockMvc.perform(
@@ -790,7 +791,7 @@ public class TmsTestFolderControllerTest {
         .andExpect(jsonPath("$.testCaseDuplicationStatistic.failureCount").value(0));
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestFolderService).duplicateFolder(projectId, folderId, request);
+    verify(tmsTestFolderService).duplicateFolder(membershipDetails, testUser, folderId, request);
   }
 
   @Test
@@ -829,7 +830,7 @@ public class TmsTestFolderControllerTest {
 
     String jsonContent = objectMapper.writeValueAsString(request);
 
-    given(tmsTestFolderService.duplicateFolder(projectId, folderId, request))
+    given(tmsTestFolderService.duplicateFolder(membershipDetails, testUser, folderId, request))
         .willReturn(expectedResponse);
 
     mockMvc.perform(
@@ -843,7 +844,7 @@ public class TmsTestFolderControllerTest {
         .andExpect(jsonPath("$.countOfTestCases").value(2));
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestFolderService).duplicateFolder(projectId, folderId, request);
+    verify(tmsTestFolderService).duplicateFolder(membershipDetails, testUser, folderId, request);
   }
 
   @Test
@@ -884,7 +885,7 @@ public class TmsTestFolderControllerTest {
 
     String jsonContent = objectMapper.writeValueAsString(request);
 
-    given(tmsTestFolderService.duplicateFolder(projectId, folderId, request))
+    given(tmsTestFolderService.duplicateFolder(membershipDetails, testUser, folderId, request))
         .willReturn(expectedResponse);
 
     mockMvc.perform(
@@ -898,7 +899,7 @@ public class TmsTestFolderControllerTest {
         .andExpect(jsonPath("$.countOfTestCases").value(3));
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestFolderService).duplicateFolder(projectId, folderId, request);
+    verify(tmsTestFolderService).duplicateFolder(membershipDetails, testUser, folderId, request);
   }
 
   @Test
@@ -940,7 +941,7 @@ public class TmsTestFolderControllerTest {
 
     String jsonContent = objectMapper.writeValueAsString(request);
 
-    given(tmsTestFolderService.duplicateFolder(projectId, folderId, request))
+    given(tmsTestFolderService.duplicateFolder(membershipDetails, testUser, folderId, request))
         .willReturn(expectedResponse);
 
     mockMvc.perform(
@@ -965,7 +966,7 @@ public class TmsTestFolderControllerTest {
             jsonPath("$.testCaseDuplicationStatistic.errors[0].errorMessage").value("Failed to duplicate test case"));
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestFolderService).duplicateFolder(projectId, folderId, request);
+    verify(tmsTestFolderService).duplicateFolder(membershipDetails, testUser, folderId, request);
   }
 
   @Test
@@ -1001,7 +1002,7 @@ public class TmsTestFolderControllerTest {
 
     String jsonContent = objectMapper.writeValueAsString(request);
 
-    given(tmsTestFolderService.duplicateFolder(projectId, folderId, request))
+    given(tmsTestFolderService.duplicateFolder(membershipDetails, testUser, folderId, request))
         .willReturn(expectedResponse);
 
     mockMvc.perform(
@@ -1016,6 +1017,6 @@ public class TmsTestFolderControllerTest {
         .andExpect(jsonPath("$.testCaseDuplicationStatistic.totalCount").value(0));
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestFolderService).duplicateFolder(projectId, folderId, request);
+    verify(tmsTestFolderService).duplicateFolder(membershipDetails, testUser, folderId, request);
   }
 }

--- a/src/test/java/com/epam/reportportal/base/core/tms/controller/unit/TmsTestPlanControllerTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/controller/unit/TmsTestPlanControllerTest.java
@@ -66,6 +66,7 @@ public class TmsTestPlanControllerTest {
   private TmsTestPlanController testPlanController;
   private MockMvc mockMvc;
   private ReportPortalUser testUser;
+  private MembershipDetails membershipDetails;
   private ObjectMapper objectMapper;
 
   @BeforeEach
@@ -104,7 +105,7 @@ public class TmsTestPlanControllerTest {
         .build();
 
     // Setup the project extractor mock to return a MembershipDetails with the projectId
-    MembershipDetails membershipDetails = MembershipDetails.builder()
+    membershipDetails = MembershipDetails.builder()
         .withProjectId(projectId)
         .withProjectKey(projectKey)
         .build();
@@ -700,7 +701,7 @@ public class TmsTestPlanControllerTest {
 
     String jsonContent = objectMapper.writeValueAsString(duplicateTestPlanRQ);
 
-    given(tmsTestPlanService.duplicate(projectId, testPlanId, duplicateTestPlanRQ))
+    given(tmsTestPlanService.duplicate(membershipDetails, testUser, testPlanId, duplicateTestPlanRQ))
         .willReturn(expectedResult);
 
     // When & Then
@@ -712,7 +713,7 @@ public class TmsTestPlanControllerTest {
         .andExpect(jsonPath("$.id").value(duplicatedTestPlanId));
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestPlanService).duplicate(projectId, testPlanId, duplicateTestPlanRQ);
+    verify(tmsTestPlanService).duplicate(membershipDetails, testUser, testPlanId, duplicateTestPlanRQ);
   }
 
   @Test
@@ -730,7 +731,7 @@ public class TmsTestPlanControllerTest {
 
     String jsonContent = objectMapper.writeValueAsString(duplicateTestPlanRQ);
 
-    given(tmsTestPlanService.duplicate(projectId, testPlanId, duplicateTestPlanRQ))
+    given(tmsTestPlanService.duplicate(membershipDetails, testUser, testPlanId, duplicateTestPlanRQ))
         .willReturn(expectedResult);
 
     // When & Then
@@ -742,7 +743,7 @@ public class TmsTestPlanControllerTest {
         .andExpect(jsonPath("$.id").value(duplicatedTestPlanId));
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestPlanService).duplicate(projectId, testPlanId, duplicateTestPlanRQ);
+    verify(tmsTestPlanService).duplicate(membershipDetails, testUser, testPlanId, duplicateTestPlanRQ);
   }
 
   @Test
@@ -759,7 +760,7 @@ public class TmsTestPlanControllerTest {
 
     String jsonContent = objectMapper.writeValueAsString(duplicateTestPlanRQ);
 
-    given(tmsTestPlanService.duplicate(projectId, testPlanId, duplicateTestPlanRQ))
+    given(tmsTestPlanService.duplicate(membershipDetails, testUser, testPlanId, duplicateTestPlanRQ))
         .willReturn(expectedResult);
 
     // When & Then
@@ -771,7 +772,7 @@ public class TmsTestPlanControllerTest {
         .andExpect(jsonPath("$.id").value(duplicatedTestPlanId));
 
     verify(projectExtractor).extractMembershipDetails(eq(testUser), anyString());
-    verify(tmsTestPlanService).duplicate(projectId, testPlanId, duplicateTestPlanRQ);
+    verify(tmsTestPlanService).duplicate(membershipDetails, testUser, testPlanId, duplicateTestPlanRQ);
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsMilestoneServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -20,10 +21,12 @@ import com.epam.reportportal.base.core.tms.dto.TmsMilestoneRQ;
 import com.epam.reportportal.base.core.tms.dto.TmsMilestoneRS;
 import com.epam.reportportal.base.core.tms.dto.TmsTestPlanRS;
 import com.epam.reportportal.base.core.tms.mapper.TmsMilestoneMapper;
+import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Filter;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.FilterCondition;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsMilestoneRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.filterable.TmsMilestoneFilterableRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.organization.MembershipDetails;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsMilestone;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
@@ -57,6 +60,12 @@ class TmsMilestoneServiceImplTest {
   @Mock
   private TmsTestPlanService tmsTestPlanService;
 
+  @Mock
+  private MembershipDetails membershipDetails;
+
+  @Mock
+  private ReportPortalUser user;
+
   @InjectMocks
   private TmsMilestoneServiceImpl sut;
 
@@ -71,6 +80,7 @@ class TmsMilestoneServiceImplTest {
     milestoneId = 100L;
     testPlanId = 200L;
     pageable = PageRequest.of(0, 10);
+    lenient().when(membershipDetails.getProjectId()).thenReturn(projectId);
   }
 
   // Tests for create method
@@ -800,7 +810,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(membershipDetails, user, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(duplicateTestPlansRS);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -808,7 +818,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(expectedRS);
 
     // When
-    var result = sut.duplicate(projectId, milestoneId, duplicateMilestoneRQ);
+    var result = sut.duplicate(membershipDetails, user, milestoneId, duplicateMilestoneRQ);
 
     // Then
     assertNotNull(result);
@@ -818,7 +828,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(membershipDetails, user, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         duplicateTestPlansRS);
@@ -835,12 +845,12 @@ class TmsMilestoneServiceImplTest {
 
     // When/Then
     var exception = assertThrows(ReportPortalException.class,
-        () -> sut.duplicate(projectId, milestoneId, duplicateMilestoneRQ));
+        () -> sut.duplicate(membershipDetails, user, milestoneId, duplicateMilestoneRQ));
 
     assertEquals(ErrorType.NOT_FOUND, exception.getErrorType());
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper, never()).toEntity(anyLong(), any());
-    verify(tmsTestPlanService, never()).duplicateTestPlansInMilestone(anyLong(), anyLong(), anyLong());
+    verify(tmsTestPlanService, never()).duplicateTestPlansInMilestone(any(), any(), anyLong(), anyLong());
     verify(tmsMilestoneRepository, never()).save(any());
   }
 
@@ -872,7 +882,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(membershipDetails, user, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(emptyDuplicateTestPlans);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -880,7 +890,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(expectedRS);
 
     // When
-    var result = sut.duplicate(projectId, milestoneId, duplicateMilestoneRQ);
+    var result = sut.duplicate(membershipDetails, user, milestoneId, duplicateMilestoneRQ);
 
     // Then
     assertNotNull(result);
@@ -890,7 +900,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(membershipDetails, user, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         emptyDuplicateTestPlans);
@@ -928,7 +938,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(Optional.of(originalMilestone));
     when(tmsMilestoneMapper.toEntity(projectId, duplicateMilestoneRQ))
         .thenReturn(newMilestoneEntity);
-    when(tmsTestPlanService.duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId()))
+    when(tmsTestPlanService.duplicateTestPlansInMilestone(membershipDetails, user, milestoneId, savedMilestoneEntity.getId()))
         .thenReturn(duplicateTestPlansRS);
     when(tmsMilestoneRepository.save(newMilestoneEntity)).thenReturn(savedMilestoneEntity);
     when(tmsMilestoneMapper.convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
@@ -936,7 +946,7 @@ class TmsMilestoneServiceImplTest {
         .thenReturn(expectedRS);
 
     // When
-    var result = sut.duplicate(projectId, milestoneId, duplicateMilestoneRQ);
+    var result = sut.duplicate(membershipDetails, user, milestoneId, duplicateMilestoneRQ);
 
     // Then
     assertNotNull(result);
@@ -946,7 +956,7 @@ class TmsMilestoneServiceImplTest {
 
     verify(tmsMilestoneRepository).findByIdAndProjectId(milestoneId, projectId);
     verify(tmsMilestoneMapper).toEntity(projectId, duplicateMilestoneRQ);
-    verify(tmsTestPlanService).duplicateTestPlansInMilestone(projectId, milestoneId, savedMilestoneEntity.getId());
+    verify(tmsTestPlanService).duplicateTestPlansInMilestone(membershipDetails, user, milestoneId, savedMilestoneEntity.getId());
     verify(tmsMilestoneRepository).save(newMilestoneEntity);
     verify(tmsMilestoneMapper).convertToDuplicateTmsMilestoneRS(savedMilestoneEntity,
         duplicateTestPlansRS);

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestCaseServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.epam.reportportal.base.core.events.domain.tms.TestCaseCreatedEvent;
 import com.epam.reportportal.base.core.tms.dto.NewTestFolderRQ;
 import com.epam.reportportal.base.core.tms.dto.TmsManualScenarioType;
 import com.epam.reportportal.base.core.tms.dto.TmsRequirementRQ;
@@ -56,6 +58,7 @@ import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestC
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestCaseVersion;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestFolder;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
+import com.epam.reportportal.base.model.activity.TestCaseActivityResource;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -180,6 +183,12 @@ class TmsTestCaseServiceImplTest {
 
     membershipDetails = mock(MembershipDetails.class);
     user = mock(ReportPortalUser.class);
+    lenient().when(membershipDetails.getProjectId()).thenReturn(projectId);
+
+    lenient().when(tmsTestCaseActivityResourceMapper.buildActivityResource(any(), any()))
+        .thenReturn(mock(TestCaseActivityResource.class));
+    lenient().when(tmsTestCaseActivityResourceMapper.buildTestCaseCreatedEvent(any(), any(), any()))
+        .thenReturn(mock(TestCaseCreatedEvent.class));
 
     attributes = new ArrayList<>();
     var attribute = new TmsTestCaseAttributeRQ();
@@ -1840,6 +1849,59 @@ class TmsTestCaseServiceImplTest {
   }
 
   @Test
+  void duplicate_WithMembershipDetailsAndUser_ShouldPublishCreatedEvent() {
+    when(membershipDetails.getProjectId()).thenReturn(projectId);
+
+    var testCaseIds = List.of(1L);
+    var targetFolderId = 10L;
+    var duplicateRequest = BatchDuplicateTestCasesRQ.builder()
+        .testCaseIds(testCaseIds)
+        .testFolderId(targetFolderId)
+        .build();
+
+    when(tmsTestCaseRepository.findExistingIdsByProjectIdAndIds(projectId, testCaseIds))
+        .thenReturn(List.of(1L));
+    when(tmsTestFolderService.resolveTargetFolderId(projectId, targetFolderId, null))
+        .thenReturn(targetFolderId);
+
+    var originalTestCase = new TmsTestCase();
+    originalTestCase.setId(1L);
+    originalTestCase.setName("Original Test Case");
+    originalTestCase.setTestFolder(testFolder);
+    var duplicatedTestCase = new TmsTestCase();
+    duplicatedTestCase.setId(20L);
+    duplicatedTestCase.setName("Original Test Case (Copy)");
+    var originalVersion = new TmsTestCaseVersion();
+    var duplicatedVersion = new TmsTestCaseVersion();
+    var duplicatedTestCaseRS = new TmsTestCaseRS();
+    duplicatedTestCaseRS.setId(20L);
+
+    when(tmsTestCaseRepository.findByProjectIdAndId(projectId, 1L))
+        .thenReturn(Optional.of(originalTestCase));
+    when(tmsTestCaseVersionService.getDefaultVersion(1L)).thenReturn(originalVersion);
+    when(tmsTestFolderService.getEntityById(projectId, targetFolderId)).thenReturn(testFolder);
+    when(tmsTestCaseMapper.duplicateTestCase(originalTestCase, testFolder))
+        .thenReturn(duplicatedTestCase);
+    when(tmsTestCaseRepository.save(duplicatedTestCase)).thenReturn(duplicatedTestCase);
+    when(tmsTestCaseVersionService.duplicateDefaultVersion(duplicatedTestCase, originalVersion))
+        .thenReturn(duplicatedVersion);
+    when(tmsTestCaseMapper.convert(duplicatedTestCase, duplicatedVersion))
+        .thenReturn(duplicatedTestCaseRS);
+
+    var result = sut.duplicate(membershipDetails, user, duplicateRequest);
+
+    assertNotNull(result);
+    assertEquals(targetFolderId, result.getTestFolderId());
+    assertNotNull(result.getTestCases());
+    assertEquals(1, result.getTestCases().size());
+    verify(tmsTestCaseRepository).findExistingIdsByProjectIdAndIds(projectId, testCaseIds);
+    verify(tmsTestFolderService).resolveTargetFolderId(projectId, targetFolderId, null);
+    verify(tmsTestCaseRepository).save(duplicatedTestCase);
+    verify(tmsTestCaseVersionService).duplicateDefaultVersion(duplicatedTestCase, originalVersion);
+    verify(eventPublisher).publishEvent(any(TestCaseCreatedEvent.class));
+  }
+
+  @Test
   void duplicate_WithValidTestCaseIds_ShouldDuplicateTestCases() {
     var testCaseIds = Arrays.asList(1L, 2L);
     var targetFolderId = 10L;
@@ -1900,7 +1962,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.convert(duplicatedTestCase2, duplicatedVersion2))
         .thenReturn(duplicatedTestCaseRS2);
 
-    var result = sut.duplicate(projectId, duplicateRequest);
+    var result = sut.duplicate(membershipDetails, user, duplicateRequest);
 
     assertNotNull(result);
     assertEquals(targetFolderId, result.getTestFolderId());
@@ -1959,7 +2021,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.convert(duplicatedTestCase, duplicatedVersion))
         .thenReturn(duplicatedTestCaseRS);
 
-    var result = sut.duplicate(projectId, duplicateRequest);
+    var result = sut.duplicate(membershipDetails, user, duplicateRequest);
 
     assertNotNull(result);
     assertEquals(targetFolderId, result.getTestFolderId());
@@ -2009,7 +2071,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.convert(duplicatedTestCase, duplicatedVersion))
         .thenReturn(duplicatedTestCaseRS);
 
-    var result = sut.duplicate(projectId, duplicateRequest);
+    var result = sut.duplicate(membershipDetails, user, duplicateRequest);
 
     assertNotNull(result);
     assertEquals(targetFolderId, result.getTestFolderId());
@@ -2033,7 +2095,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseRepository.findExistingIdsByProjectIdAndIds(projectId, testCaseIds))
         .thenReturn(Collections.emptyList());
 
-    assertThrows(ReportPortalException.class, () -> sut.duplicate(projectId, duplicateRequest));
+    assertThrows(ReportPortalException.class, () -> sut.duplicate(membershipDetails, user, duplicateRequest));
     verify(tmsTestCaseRepository).findExistingIdsByProjectIdAndIds(projectId, testCaseIds);
     verify(tmsTestFolderService, never()).resolveTargetFolderId(any(Long.class), any(), any());
     verify(tmsTestCaseRepository, never()).save(any());
@@ -2052,7 +2114,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestFolderService.resolveTargetFolderId(projectId, 10L, null)).thenReturn(10L);
     when(tmsTestCaseRepository.findByProjectIdAndId(projectId, 1L)).thenReturn(Optional.empty());
 
-    assertThrows(ReportPortalException.class, () -> sut.duplicate(projectId, duplicateRequest));
+    assertThrows(ReportPortalException.class, () -> sut.duplicate(membershipDetails, user, duplicateRequest));
     verify(tmsTestCaseRepository).findExistingIdsByProjectIdAndIds(projectId, testCaseIds);
     verify(tmsTestFolderService).resolveTargetFolderId(projectId, 10L, null);
     verify(tmsTestCaseRepository).findByProjectIdAndId(projectId, 1L);
@@ -2073,7 +2135,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestFolderService.resolveTargetFolderId(projectId, targetFolderId, null))
         .thenReturn(targetFolderId);
 
-    var result = sut.duplicate(projectId, duplicateRequest);
+    var result = sut.duplicate(membershipDetails, user, duplicateRequest);
 
     assertNotNull(result);
     assertEquals(targetFolderId, result.getTestFolderId());
@@ -2109,7 +2171,7 @@ class TmsTestCaseServiceImplTest {
         .thenReturn(duplicatedVersion);
     when(tmsTestCaseMapper.convert(duplicatedTestCase, duplicatedVersion)).thenReturn(testCaseRS);
 
-    var result = sut.duplicateTestCase(projectId, 1L, testFolderId);
+    var result = sut.duplicateTestCase(membershipDetails, user, projectId, 1L, testFolderId);
 
     assertNotNull(result);
     verify(tmsTestCaseRepository).save(duplicatedTestCase);
@@ -2139,7 +2201,7 @@ class TmsTestCaseServiceImplTest {
         .thenReturn(duplicatedVersion);
     when(tmsTestCaseMapper.convert(duplicatedTestCase, duplicatedVersion)).thenReturn(testCaseRS);
 
-    var result = sut.duplicateTestCase(projectId, 1L, testFolderId);
+    var result = sut.duplicateTestCase(membershipDetails, user, projectId, 1L, testFolderId);
 
     assertNotNull(result);
     verify(tmsTestCaseRepository).save(duplicatedTestCase);
@@ -2191,7 +2253,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(
         Arrays.asList(11L, 12L), Collections.emptyList())).thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, testCaseIds);
 
     assertNotNull(result);
     assertEquals(2, result.getSuccessTestCaseIds().size());
@@ -2234,7 +2296,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(eq(List.of(11L)), anyList()))
         .thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, testCaseIds);
 
     assertNotNull(result);
     assertEquals(1, result.getSuccessTestCaseIds().size());
@@ -2276,7 +2338,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(List.of(11L), Collections.emptyList()))
         .thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, testCaseIds);
 
     assertNotNull(result);
     verify(tmsTestCaseAttributeService)
@@ -2435,7 +2497,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(
         Arrays.asList(11L, 12L), Collections.emptyList())).thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(2, result.getSuccessTestCaseIds().size());
@@ -2494,7 +2556,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(List.of(11L), Collections.emptyList()))
         .thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(1, result.getSuccessTestCaseIds().size());
@@ -2539,7 +2601,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(List.of(11L), Collections.emptyList()))
         .thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(1, result.getSuccessTestCaseIds().size());
@@ -2562,7 +2624,7 @@ class TmsTestCaseServiceImplTest {
                 "Failed to duplicate test case: Test Case with id: 999 for project: 1")))
             .build());
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertTrue(result.getSuccessTestCaseIds().isEmpty());
@@ -2628,7 +2690,7 @@ class TmsTestCaseServiceImplTest {
                 "Failed to duplicate test case: Test Case with id: 999 for project: 1")))
             .build());
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(2, result.getSuccessTestCaseIds().size());
@@ -2675,7 +2737,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(List.of(11L), Collections.emptyList()))
         .thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(1, result.getSuccessTestCaseIds().size());
@@ -2695,7 +2757,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(
         Collections.emptyList(), Collections.emptyList())).thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, emptyTestCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, emptyTestCaseIds);
 
     assertNotNull(result);
     assertTrue(result.getSuccessTestCaseIds().isEmpty());
@@ -2726,7 +2788,7 @@ class TmsTestCaseServiceImplTest {
                     "Failed to duplicate test case: Test Case with id: 999 for project: 1")))
             .build());
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertTrue(result.getSuccessTestCaseIds().isEmpty());
@@ -2768,7 +2830,7 @@ class TmsTestCaseServiceImplTest {
                 "Failed to duplicate test case: Database error")))
             .build());
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertTrue(result.getSuccessTestCaseIds().isEmpty());
@@ -2811,7 +2873,7 @@ class TmsTestCaseServiceImplTest {
                 "Failed to duplicate test case: Version duplication failed")))
             .build());
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertTrue(result.getSuccessTestCaseIds().isEmpty());
@@ -2859,7 +2921,7 @@ class TmsTestCaseServiceImplTest {
                 "Failed to duplicate test case: Attribute duplication failed")))
             .build());
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertTrue(result.getSuccessTestCaseIds().isEmpty());
@@ -2904,7 +2966,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(List.of(11L), Collections.emptyList()))
         .thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(1, result.getSuccessTestCaseIds().size());
@@ -2944,7 +3006,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(List.of(11L), Collections.emptyList()))
         .thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(1, result.getSuccessTestCaseIds().size());
@@ -3009,7 +3071,7 @@ class TmsTestCaseServiceImplTest {
                     "Failed to duplicate test case: Test Case with id: 998 for project: 1")))
             .build());
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(2, result.getSuccessTestCaseIds().size());
@@ -3055,7 +3117,7 @@ class TmsTestCaseServiceImplTest {
     when(tmsTestCaseMapper.toBatchOperationResult(List.of(11L), Collections.emptyList()))
         .thenReturn(expectedResult);
 
-    var result = sut.duplicateTestCases(projectId, targetFolder, testCaseIds);
+    var result = sut.duplicateTestCases(membershipDetails, user, targetFolder, testCaseIds);
 
     assertNotNull(result);
     assertEquals(1, result.getSuccessTestCaseIds().size());

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestFolderServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestFolderServiceImplTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -95,6 +96,10 @@ class TmsTestFolderServiceImplTest {
   private HttpServletResponse mockResponse;
   @Mock
   private Filter filter;
+  @Mock
+  private MembershipDetails membershipDetails;
+  @Mock
+  private ReportPortalUser user;
   @InjectMocks
   private TmsTestFolderServiceImpl sut;
 
@@ -118,6 +123,7 @@ class TmsTestFolderServiceImplTest {
 
   @BeforeEach
   void setUp() {
+    lenient().when(membershipDetails.getProjectId()).thenReturn(projectId);
     project = new Project();
     project.setId(projectId);
 
@@ -1459,7 +1465,7 @@ class TmsTestFolderServiceImplTest {
         .successTestCaseIds(Arrays.asList(10L, 11L))
         .errors(Collections.emptyList())
         .build();
-    when(tmsTestCaseService.duplicateTestCases(eq(projectId), any(TmsTestFolder.class),
+    when(tmsTestCaseService.duplicateTestCases(eq(membershipDetails), eq(user), any(TmsTestFolder.class),
         anyList()))
         .thenReturn(testCaseResult);
 
@@ -1472,7 +1478,7 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
@@ -1544,7 +1550,7 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
@@ -1620,7 +1626,7 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
@@ -1737,7 +1743,7 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
@@ -1818,7 +1824,7 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
@@ -1890,7 +1896,7 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
@@ -1970,7 +1976,7 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
@@ -2004,7 +2010,7 @@ class TmsTestFolderServiceImplTest {
 
     // Act & Assert
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicateFolder(projectId, rootFolderId, duplicateRQ));
+        sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ));
 
     assertTrue(exception.getMessage().contains(
         String.format("Test Folder with id: %d for project: %d", nonExistentParentId, projectId)));
@@ -2036,7 +2042,7 @@ class TmsTestFolderServiceImplTest {
 
     // Act & Assert
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicateFolder(projectId, rootFolderId, duplicateRQ));
+        sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ));
 
     assertTrue(exception.getMessage().contains(
         String.format("Test Folder with id: %d for project: %d", nonExistentGrandparentId,
@@ -2063,7 +2069,7 @@ class TmsTestFolderServiceImplTest {
 
     // Act & Assert
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicateFolder(projectId, rootFolderId, duplicateRQ));
+        sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ));
 
     assertTrue(exception.getMessage().contains(
         "Either parent folder id or parent folder name should be set"));
@@ -2086,7 +2092,7 @@ class TmsTestFolderServiceImplTest {
 
     // Act & Assert
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicateFolder(projectId, rootFolderId, duplicateRQ));
+        sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ));
 
     assertTrue(exception.getMessage().contains(
         "Either parent folder id or parent folder name should be set"));
@@ -2105,7 +2111,7 @@ class TmsTestFolderServiceImplTest {
 
     // Act & Assert
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicateFolder(projectId, nonExistentFolderId, duplicateRQ));
+        sut.duplicateFolder(membershipDetails, user, nonExistentFolderId, duplicateRQ));
 
     assertTrue(exception.getMessage().contains(
         String.format("'Test Folder with id: %d for project: %d'", nonExistentFolderId,
@@ -2160,7 +2166,7 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
@@ -2216,7 +2222,7 @@ class TmsTestFolderServiceImplTest {
     // Mock test case duplication - now passes entities instead of IDs
     when(tmsTestFolderRepository.findTestCaseIdsByFolderId(rootFolderId))
         .thenReturn(testCaseIds);
-    when(tmsTestCaseService.duplicateTestCases(projectId, duplicatedFolder, testCaseIds))
+    when(tmsTestCaseService.duplicateTestCases(membershipDetails, user, duplicatedFolder, testCaseIds))
         .thenReturn(testCaseResult);
 
     when(tmsTestFolderRepository.countTestCasesByFolderId(100L)).thenReturn(3L);
@@ -2228,14 +2234,14 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
     assertEquals(3L, result.getCountOfTestCases());
 
     verify(tmsTestFolderRepository).findTestCaseIdsByFolderId(rootFolderId);
-    verify(tmsTestCaseService).duplicateTestCases(projectId, duplicatedFolder, testCaseIds);
+    verify(tmsTestCaseService).duplicateTestCases(membershipDetails, user, duplicatedFolder, testCaseIds);
     // Note: updateTestCaseFolder is no longer called, it's handled inside duplicateTestCases
     verify(tmsTestFolderRepository, never()).updateTestCaseFolder(anyList(), anyLong());
   }
@@ -2286,7 +2292,7 @@ class TmsTestFolderServiceImplTest {
     // Mock test case duplication with partial failure
     when(tmsTestFolderRepository.findTestCaseIdsByFolderId(rootFolderId))
         .thenReturn(testCaseIds);
-    when(tmsTestCaseService.duplicateTestCases(projectId, duplicatedFolder, testCaseIds))
+    when(tmsTestCaseService.duplicateTestCases(membershipDetails, user, duplicatedFolder, testCaseIds))
         .thenReturn(testCaseResult);
 
     when(tmsTestFolderRepository.countTestCasesByFolderId(100L)).thenReturn(1L);
@@ -2298,12 +2304,12 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
 
-    verify(tmsTestCaseService).duplicateTestCases(projectId, duplicatedFolder, testCaseIds);
+    verify(tmsTestCaseService).duplicateTestCases(membershipDetails, user, duplicatedFolder, testCaseIds);
   }
 
   @Test
@@ -2344,7 +2350,7 @@ class TmsTestFolderServiceImplTest {
     // Mock test case duplication with exception
     when(tmsTestFolderRepository.findTestCaseIdsByFolderId(rootFolderId))
         .thenReturn(testCaseIds);
-    when(tmsTestCaseService.duplicateTestCases(projectId, duplicatedFolder, testCaseIds))
+    when(tmsTestCaseService.duplicateTestCases(membershipDetails, user, duplicatedFolder, testCaseIds))
         .thenThrow(new RuntimeException("Test case duplication failed"));
 
     when(tmsTestFolderRepository.countTestCasesByFolderId(100L)).thenReturn(0L);
@@ -2356,12 +2362,12 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
 
-    verify(tmsTestCaseService).duplicateTestCases(projectId, duplicatedFolder, testCaseIds);
+    verify(tmsTestCaseService).duplicateTestCases(membershipDetails, user, duplicatedFolder, testCaseIds);
   }
 
   @Test
@@ -2410,14 +2416,14 @@ class TmsTestFolderServiceImplTest {
     )).thenReturn(expectedResponse);
 
     // Act
-    var result = sut.duplicateFolder(projectId, rootFolderId, duplicateRQ);
+    var result = sut.duplicateFolder(membershipDetails, user, rootFolderId, duplicateRQ);
 
     // Assert
     assertNotNull(result);
     assertEquals(0L, result.getCountOfTestCases());
 
     verify(tmsTestFolderRepository).findTestCaseIdsByFolderId(rootFolderId);
-    verify(tmsTestCaseService, never()).duplicateTestCases(anyLong(), any(TmsTestFolder.class),
+    verify(tmsTestCaseService, never()).duplicateTestCases(any(), any(), any(TmsTestFolder.class),
         anyList());
   }
 

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsTestPlanServiceImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -27,11 +28,13 @@ import com.epam.reportportal.base.core.tms.dto.TmsTestPlanRS;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchTestCaseOperationError;
 import com.epam.reportportal.base.core.tms.dto.batch.BatchTestCaseOperationResultRS;
 import com.epam.reportportal.base.core.tms.mapper.TmsTestPlanMapper;
+import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.commons.querygen.Filter;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestCaseRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestPlanRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTestPlanTestCaseRepository;
 import com.epam.reportportal.base.infrastructure.persistence.dao.tms.filterable.TmsTestPlanFilterableRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.organization.MembershipDetails;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestPlan;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.projection.TmsTestPlanName;
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsTestPlanWithStatistic;
@@ -83,6 +86,12 @@ class TmsTestPlanServiceImplTest {
   @Mock
   private TmsTestFolderService tmsTestFolderService;
 
+  @Mock
+  private MembershipDetails membershipDetails;
+
+  @Mock
+  private ReportPortalUser user;
+
   @InjectMocks
   private TmsTestPlanServiceImpl sut;
 
@@ -99,6 +108,7 @@ class TmsTestPlanServiceImplTest {
     testCaseId = 10L;
     milestoneId = 50L;
     pageable = PageRequest.of(0, 10);
+    lenient().when(membershipDetails.getProjectId()).thenReturn(projectId);
   }
 
   @Test
@@ -711,7 +721,7 @@ class TmsTestPlanServiceImplTest {
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
         .thenReturn(originalTestCaseIds);
-    when(tmsTestCaseService.duplicateTestCases(projectId, originalTestCaseIds))
+    when(tmsTestCaseService.duplicateTestCases(membershipDetails, user, originalTestCaseIds))
         .thenReturn(duplicationResult);
     when(tmsTestCaseService.getExistingTestCaseIds(projectId, duplicatedTestCaseIds))
         .thenReturn(duplicatedTestCaseIds);
@@ -727,7 +737,7 @@ class TmsTestPlanServiceImplTest {
     when(tmsTestPlanMapper.buildDuplicateTestPlanResponse(duplicatedTestPlan, combinedResult))
         .thenReturn(expectedResponse);
 
-    var result = sut.duplicate(projectId, testPlanId, duplicateTestPlanRQ);
+    var result = sut.duplicate(membershipDetails, user, testPlanId, duplicateTestPlanRQ);
 
     assertNotNull(result);
     assertEquals(3L, result.getId());
@@ -738,7 +748,7 @@ class TmsTestPlanServiceImplTest {
         projectId, duplicatedTestPlan, duplicateTestPlanRQ.getAttributes()
     );
     verify(tmsTestPlanTestCaseRepository).findTestCaseIdsByTestPlanId(testPlanId);
-    verify(tmsTestCaseService).duplicateTestCases(projectId, originalTestCaseIds);
+    verify(tmsTestCaseService).duplicateTestCases(membershipDetails, user, originalTestCaseIds);
     verify(tmsTestPlanMapper).buildDuplicateTestPlanResponse(duplicatedTestPlan, combinedResult);
   }
 
@@ -778,7 +788,7 @@ class TmsTestPlanServiceImplTest {
     when(tmsTestPlanMapper.buildDuplicateTestPlanResponse(duplicatedTestPlan, emptyResult))
         .thenReturn(expectedResponse);
 
-    var result = sut.duplicate(projectId, testPlanId, duplicateTestPlanRQ);
+    var result = sut.duplicate(membershipDetails, user, testPlanId, duplicateTestPlanRQ);
 
     assertNotNull(result);
     assertEquals(3L, result.getId());
@@ -788,7 +798,7 @@ class TmsTestPlanServiceImplTest {
     verify(tmsTestPlanAttributeService).createTestPlanAttributes(
         projectId, duplicatedTestPlan, duplicateTestPlanRQ.getAttributes()
     );
-    verify(tmsTestCaseService, never()).duplicateTestCases(anyLong(), anyList());
+    verify(tmsTestCaseService, never()).duplicateTestCases(any(), any(), anyList());
     verify(tmsTestPlanMapper).buildDuplicateTestPlanResponse(duplicatedTestPlan, emptyResult);
   }
 
@@ -802,7 +812,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(Optional.empty());
 
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicate(projectId, testPlanId, duplicateTestPlanRQ)
+        sut.duplicate(membershipDetails, user, testPlanId, duplicateTestPlanRQ)
     );
 
     assertEquals(ErrorType.NOT_FOUND, exception.getErrorType());
@@ -860,7 +870,7 @@ class TmsTestPlanServiceImplTest {
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
         .thenReturn(originalTestCaseIds);
-    when(tmsTestCaseService.duplicateTestCases(projectId, originalTestCaseIds))
+    when(tmsTestCaseService.duplicateTestCases(membershipDetails, user, originalTestCaseIds))
         .thenReturn(duplicationResult);
     when(tmsTestCaseService.getExistingTestCaseIds(projectId, duplicatedTestCaseIds))
         .thenReturn(duplicatedTestCaseIds);
@@ -876,13 +886,13 @@ class TmsTestPlanServiceImplTest {
     when(tmsTestPlanMapper.buildDuplicateTestPlanResponse(duplicatedTestPlan, combinedResult))
         .thenReturn(expectedResponse);
 
-    var result = sut.duplicate(projectId, testPlanId, duplicateTestPlanRQ);
+    var result = sut.duplicate(membershipDetails, user, testPlanId, duplicateTestPlanRQ);
 
     assertNotNull(result);
     assertEquals(3L, result.getId());
     assertNotNull(result.getDuplicationStatistic());
     assertEquals(1, result.getDuplicationStatistic().getFailureCount());
-    verify(tmsTestCaseService).duplicateTestCases(projectId, originalTestCaseIds);
+    verify(tmsTestCaseService).duplicateTestCases(membershipDetails, user, originalTestCaseIds);
     verify(tmsTestPlanMapper).combineDuplicateTestPlanBatchResults(duplicationResult, addToPlanResult);
   }
 
@@ -923,19 +933,19 @@ class TmsTestPlanServiceImplTest {
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
         .thenReturn(originalTestCaseIds);
-    when(tmsTestCaseService.duplicateTestCases(projectId, originalTestCaseIds))
+    when(tmsTestCaseService.duplicateTestCases(membershipDetails, user, originalTestCaseIds))
         .thenReturn(duplicationResult);
     when(tmsTestPlanMapper.buildDuplicateTestPlanResponse(duplicatedTestPlan, duplicationResult))
         .thenReturn(expectedResponse);
 
-    var result = sut.duplicate(projectId, testPlanId, duplicateTestPlanRQ);
+    var result = sut.duplicate(membershipDetails, user, testPlanId, duplicateTestPlanRQ);
 
     assertNotNull(result);
     assertEquals(3L, result.getId());
     assertNotNull(result.getDuplicationStatistic());
     assertEquals(2, result.getDuplicationStatistic().getFailureCount());
     assertEquals(0, result.getDuplicationStatistic().getSuccessCount());
-    verify(tmsTestCaseService).duplicateTestCases(projectId, originalTestCaseIds);
+    verify(tmsTestCaseService).duplicateTestCases(membershipDetails, user, originalTestCaseIds);
     verify(tmsTestCaseService, never()).getExistingTestCaseIds(anyLong(), anyList());
     verify(tmsTestPlanMapper, never()).combineDuplicateTestPlanBatchResults(any(), any());
   }
@@ -992,7 +1002,7 @@ class TmsTestPlanServiceImplTest {
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
         .thenReturn(originalTestCaseIds);
-    when(tmsTestCaseService.duplicateTestCases(projectId, originalTestCaseIds))
+    when(tmsTestCaseService.duplicateTestCases(membershipDetails, user, originalTestCaseIds))
         .thenReturn(duplicationResult);
     when(testPlanRepository.existsByIdAndProject_Id(3L, projectId))
         .thenThrow(new RuntimeException("Database error"));
@@ -1004,7 +1014,7 @@ class TmsTestPlanServiceImplTest {
     when(tmsTestPlanMapper.buildDuplicateTestPlanResponse(duplicatedTestPlan, combinedResult))
         .thenReturn(expectedResponse);
 
-    var result = sut.duplicate(projectId, testPlanId, duplicateTestPlanRQ);
+    var result = sut.duplicate(membershipDetails, user, testPlanId, duplicateTestPlanRQ);
 
     assertNotNull(result);
     assertEquals(3L, result.getId());
@@ -1062,7 +1072,7 @@ class TmsTestPlanServiceImplTest {
     when(testPlanRepository.save(duplicatedTestPlan)).thenReturn(duplicatedTestPlan);
     when(tmsTestPlanTestCaseRepository.findTestCaseIdsByTestPlanId(testPlanId))
         .thenReturn(originalTestCaseIds);
-    when(tmsTestCaseService.duplicateTestCases(projectId, originalTestCaseIds))
+    when(tmsTestCaseService.duplicateTestCases(membershipDetails, user, originalTestCaseIds))
         .thenReturn(duplicationResult);
     when(tmsTestCaseService.getExistingTestCaseIds(projectId, duplicatedTestCaseIds))
         .thenReturn(duplicatedTestCaseIds);
@@ -1079,7 +1089,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(expectedResponse);
 
     // When
-    var result = sut.duplicate(projectId, testPlanId, (Long) null);
+    var result = sut.duplicate(membershipDetails, user, testPlanId, (Long) null);
 
     // Then
     assertNotNull(result);
@@ -1089,7 +1099,7 @@ class TmsTestPlanServiceImplTest {
     verify(testPlanRepository).save(duplicatedTestPlan);
     verify(tmsTestPlanAttributeService).duplicateTestPlanAttributes(originalTestPlan, duplicatedTestPlan);
     verify(tmsTestPlanTestCaseRepository).findTestCaseIdsByTestPlanId(testPlanId);
-    verify(tmsTestCaseService).duplicateTestCases(projectId, originalTestCaseIds);
+    verify(tmsTestCaseService).duplicateTestCases(membershipDetails, user, originalTestCaseIds);
     verify(tmsTestPlanMapper).buildDuplicateTestPlanResponse(duplicatedTestPlan, combinedResult);
   }
 
@@ -1127,7 +1137,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(expectedResponse);
 
     // When
-    var result = sut.duplicate(projectId, testPlanId, (Long) null);
+    var result = sut.duplicate(membershipDetails, user, testPlanId, (Long) null);
 
     // Then
     assertNotNull(result);
@@ -1136,7 +1146,7 @@ class TmsTestPlanServiceImplTest {
     verify(tmsTestPlanMapper).duplicateTestPlan(originalTestPlan, (Long) null);
     verify(testPlanRepository).save(duplicatedTestPlan);
     verify(tmsTestPlanAttributeService).duplicateTestPlanAttributes(originalTestPlan, duplicatedTestPlan);
-    verify(tmsTestCaseService, never()).duplicateTestCases(anyLong(), anyList());
+    verify(tmsTestCaseService, never()).duplicateTestCases(any(), any(), anyList());
     verify(tmsTestPlanMapper).buildDuplicateTestPlanResponse(duplicatedTestPlan, emptyResult);
   }
 
@@ -1148,7 +1158,7 @@ class TmsTestPlanServiceImplTest {
 
     // When/Then
     var exception = assertThrows(ReportPortalException.class, () ->
-        sut.duplicate(projectId, testPlanId, (Long) null)
+        sut.duplicate(membershipDetails, user, testPlanId, (Long) null)
     );
 
     assertEquals(ErrorType.NOT_FOUND, exception.getErrorType());
@@ -1657,7 +1667,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(duplicatedPlan2);
 
     // When
-    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId, targetMilestoneId);
+    var result = sut.duplicateTestPlansInMilestone(membershipDetails, user, milestoneId, targetMilestoneId);
 
     // Then
     assertNotNull(result);
@@ -1679,7 +1689,7 @@ class TmsTestPlanServiceImplTest {
         .thenReturn(List.of());
 
     // When
-    var result = sut.duplicateTestPlansInMilestone(projectId, milestoneId, 999L);
+    var result = sut.duplicateTestPlansInMilestone(membershipDetails, user, milestoneId, 999L);
 
     // Then
     assertNotNull(result);


### PR DESCRIPTION
### Summary
Fixes [EPMRPP-118812](https://jiraeu.epam.com/browse/EPMRPP-118812).

### Problem
When test cases are duplicated (either directly via batch duplication or via folder duplication), no activity history events (`Created Test Case`) were being generated or published. Consequently, duplicated test cases had an empty "History of Actions" in the UI.

### Solution
- Updated `TestCaseController.duplicateTestCases` to extract `MembershipDetails` and `ReportPortalUser` from authentication context and pass them to `TmsTestCaseService.duplicate`.
- Updated `TmsTestCaseService` interface and `TmsTestCaseServiceImpl` to support `duplicate(MembershipDetails, ReportPortalUser, BatchDuplicateTestCasesRQ)`.
- Added publication of `TestCaseCreatedEvent` in `TmsTestCaseServiceImpl` during test case duplication (using `membershipDetails` and `user` context when present, or resolving via `SecurityContextUtils`).
- Updated and added unit tests in `TmsTestCaseControllerTest` and `TmsTestCaseServiceImplTest` to verify event publication upon duplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicating test cases now publishes creation events.
  * Test case, test folder, test plan, and milestone duplication now preserves authenticated access context.
* **Bug Fixes**
  * Improved handling of duplicated items across project contexts.
  * Preserved source-folder placement when no destination folder is selected.
  * Test case priorities are now consistently saved in uppercase.
* **Tests**
  * Added coverage for duplication events and priority normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->