### PR TITLE
EPMRPP-118637 || Fix stale analyzer version shown as available when analyzer is down

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/analyzer/auto/client/RabbitMqManagementClient.java
+++ b/src/main/java/com/epam/reportportal/base/core/analyzer/auto/client/RabbitMqManagementClient.java
@@ -18,6 +18,7 @@ package com.epam.reportportal.base.core.analyzer.auto.client;
 
 import com.rabbitmq.http.client.domain.ExchangeInfo;
 import java.util.List;
+import java.util.Set;
 
 /**
  * HTTP management API for listing analyzer-related RabbitMQ exchanges.
@@ -28,4 +29,5 @@ public interface RabbitMqManagementClient {
 
   List<ExchangeInfo> getAnalyzerExchangesInfo();
 
+  Set<String> getExchangesWithActiveConsumers();
 }

--- a/src/main/java/com/epam/reportportal/base/core/analyzer/auto/client/impl/RabbitMqManagementClientTemplate.java
+++ b/src/main/java/com/epam/reportportal/base/core/analyzer/auto/client/impl/RabbitMqManagementClientTemplate.java
@@ -24,15 +24,22 @@ import com.epam.reportportal.base.core.analyzer.auto.client.RabbitMqManagementCl
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import com.rabbitmq.http.client.Client;
+import com.rabbitmq.http.client.domain.BindingInfo;
+import com.rabbitmq.http.client.domain.DestinationType;
 import com.rabbitmq.http.client.domain.ExchangeInfo;
+import com.rabbitmq.http.client.domain.QueueInfo;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 
 /**
  * Rabbit management client filtered to analyzer exchange metadata.
  *
  * @author <a href="mailto:ihar_kahadouski@epam.com">Ihar Kahadouski</a>
  */
+@Slf4j
 public class RabbitMqManagementClientTemplate implements RabbitMqManagementClient {
 
   private final Client rabbitClient;
@@ -50,6 +57,7 @@ public class RabbitMqManagementClientTemplate implements RabbitMqManagementClien
     }
   }
 
+  @Override
   public List<ExchangeInfo> getAnalyzerExchangesInfo() {
     List<ExchangeInfo> client = rabbitClient.getExchanges(virtualHost);
     if (client == null) {
@@ -59,5 +67,27 @@ public class RabbitMqManagementClientTemplate implements RabbitMqManagementClien
         .filter(it -> it.getArguments().get(ANALYZER_KEY) != null)
         .sorted(comparingInt(EXCHANGE_PRIORITY))
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Exchanges that have at least one queue bound with an active consumer.
+   * Computed from a single queues fetch and a single bindings fetch to avoid per-exchange calls.
+   */
+  public Set<String> getExchangesWithActiveConsumers() {
+    Set<String> queuesWithConsumers = CollectionUtils.emptyIfNull(rabbitClient.getQueues(virtualHost)).stream()
+        .filter(queue -> queue.getConsumerCount() > 0)
+        .map(QueueInfo::getName)
+        .collect(Collectors.toSet());
+
+    if (queuesWithConsumers.isEmpty()) {
+      return Set.of();
+    }
+
+    return CollectionUtils.emptyIfNull(rabbitClient.getBindings(virtualHost))
+        .stream()
+        .filter(binding -> binding.getDestinationType() == DestinationType.QUEUE)
+        .filter(binding -> queuesWithConsumers.contains(binding.getDestination()))
+        .map(BindingInfo::getSource)
+        .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/com/epam/reportportal/base/info/AnalyzerInfoContributor.java
+++ b/src/main/java/com/epam/reportportal/base/info/AnalyzerInfoContributor.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AnalyzerInfoContributor implements ExtensionContributor {
 
-  static final String AVAILABLE_KEY = "available";
+  private static final String AVAILABLE_KEY = "available";
 
   private final RabbitMqManagementClient managementClient;
 

--- a/src/main/java/com/epam/reportportal/base/info/AnalyzerInfoContributor.java
+++ b/src/main/java/com/epam/reportportal/base/info/AnalyzerInfoContributor.java
@@ -17,13 +17,12 @@
 package com.epam.reportportal.base.info;
 
 import com.epam.reportportal.base.core.analyzer.auto.client.RabbitMqManagementClient;
-import com.google.common.collect.ImmutableMap;
 import com.rabbitmq.http.client.domain.ExchangeInfo;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /**
@@ -32,21 +31,26 @@ import org.springframework.stereotype.Component;
  * @author Pavel Bortnik
  */
 @Component
+@RequiredArgsConstructor
 public class AnalyzerInfoContributor implements ExtensionContributor {
+
+  static final String AVAILABLE_KEY = "available";
 
   private final RabbitMqManagementClient managementClient;
 
-  @Autowired
-  public AnalyzerInfoContributor(RabbitMqManagementClient managementClient) {
-    this.managementClient = managementClient;
-  }
-
   @Override
   public Map<String, ?> contribute() {
-    Set<Object> analyzersInfo = managementClient.getAnalyzerExchangesInfo()
+    Set<String> exchangesWithConsumers = managementClient.getExchangesWithActiveConsumers();
+    Set<Map<String, Object>> analyzersInfo = managementClient.getAnalyzerExchangesInfo()
         .stream()
-        .map((Function<ExchangeInfo, Object>) ExchangeInfo::getArguments)
+        .map(exchange -> toAnalyzerInfo(exchange, exchangesWithConsumers))
         .collect(Collectors.toSet());
-    return ImmutableMap.<String, Object>builder().put("analyzers", analyzersInfo).build();
+    return Map.of("analyzers", analyzersInfo);
+  }
+
+  private Map<String, Object> toAnalyzerInfo(ExchangeInfo exchange, Set<String> exchangesWithConsumers) {
+    Map<String, Object> info = new HashMap<>(exchange.getArguments());
+    info.put(AVAILABLE_KEY, exchangesWithConsumers.contains(exchange.getName()));
+    return info;
   }
 }

--- a/src/main/java/com/epam/reportportal/base/info/InfoContributorComposite.java
+++ b/src/main/java/com/epam/reportportal/base/info/InfoContributorComposite.java
@@ -19,7 +19,7 @@ package com.epam.reportportal.base.info;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.info.Info;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.stereotype.Component;
@@ -29,18 +29,13 @@ import org.springframework.stereotype.Component;
  *
  * @author Pavel Bortnik
  */
-
 @Component
+@RequiredArgsConstructor
 public class InfoContributorComposite implements InfoContributor {
 
   private static final String EXTENSIONS_KEY = "extensions";
 
   private final List<ExtensionContributor> infoContributors;
-
-  @Autowired
-  public InfoContributorComposite(List<ExtensionContributor> infoContributors) {
-    this.infoContributors = infoContributors;
-  }
 
   @Override
   public void contribute(Info.Builder builder) {

--- a/src/test/java/com/epam/reportportal/base/core/analyzer/auto/client/impl/RabbitMqManagementClientTemplateTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/analyzer/auto/client/impl/RabbitMqManagementClientTemplateTest.java
@@ -16,31 +16,98 @@
 
 package com.epam.reportportal.base.core.analyzer.auto.client.impl;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import com.rabbitmq.http.client.Client;
+import com.rabbitmq.http.client.domain.BindingInfo;
+import com.rabbitmq.http.client.domain.DestinationType;
+import com.rabbitmq.http.client.domain.QueueInfo;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class RabbitMqManagementClientTemplateTest {
+class RabbitMqManagementClientTemplateTest {
+
+  private static final String VHOST = "analyzer";
 
   @Mock
   private Client rabbitClient;
 
   private RabbitMqManagementClientTemplate template;
 
+  @BeforeEach
+  void setUp() {
+    template = new RabbitMqManagementClientTemplate(rabbitClient, VHOST);
+  }
+
   @Test
-  public void testReportPortalExceptionOnGetExchanges() {
-    template = new RabbitMqManagementClientTemplate(rabbitClient, "analyzer");
+  void getAnalyzerExchangesInfoShouldThrowWhenExchangesAreNull() {
+    // given
+    when(rabbitClient.getExchanges(VHOST)).thenReturn(null);
 
-    when(rabbitClient.getExchanges("analyzer")).thenReturn(null);
+    // when / then
+    assertThrows(ReportPortalException.class, () -> template.getAnalyzerExchangesInfo());
+  }
 
-    assertThatThrownBy(() -> template.getAnalyzerExchangesInfo()).isInstanceOf(
-        ReportPortalException.class);
+  @Test
+  void getExchangesWithActiveConsumersShouldReturnExchangeWhenBoundQueueHasConsumers() {
+    // given
+    when(rabbitClient.getQueues(VHOST)).thenReturn(List.of(queue(1)));
+    when(rabbitClient.getBindings(VHOST)).thenReturn(List.of(queueBinding()));
+
+    // when
+    Set<String> result = template.getExchangesWithActiveConsumers();
+
+    // then
+    assertEquals(Set.of("analyzer"), result);
+  }
+
+  @Test
+  void getExchangesWithActiveConsumersShouldReturnEmptyWhenNoQueueHasConsumers() {
+    // given
+    when(rabbitClient.getQueues(VHOST)).thenReturn(List.of(queue(0)));
+
+    // when
+    Set<String> result = template.getExchangesWithActiveConsumers();
+
+    // then
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void getExchangesWithActiveConsumersShouldReturnEmptyWhenConsumingQueueIsNotBound() {
+    // given
+    when(rabbitClient.getQueues(VHOST)).thenReturn(List.of(queue(1)));
+    when(rabbitClient.getBindings(VHOST)).thenReturn(List.of());
+
+    // when
+    Set<String> result = template.getExchangesWithActiveConsumers();
+
+    // then
+    assertTrue(result.isEmpty());
+  }
+
+  private static QueueInfo queue(int consumerCount) {
+    QueueInfo queue = new QueueInfo();
+    queue.setName("all");
+    queue.setConsumerCount(consumerCount);
+    return queue;
+  }
+
+  private static BindingInfo queueBinding() {
+    BindingInfo binding = new BindingInfo();
+    binding.setSource("analyzer");
+    binding.setDestinationType(DestinationType.QUEUE);
+    binding.setDestination("all");
+    return binding;
   }
 }

--- a/src/test/java/com/epam/reportportal/base/info/AnalyzerInfoContributorTest.java
+++ b/src/test/java/com/epam/reportportal/base/info/AnalyzerInfoContributorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.info;
+
+import static com.epam.reportportal.base.info.AnalyzerInfoContributor.AVAILABLE_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.epam.reportportal.base.core.analyzer.auto.client.RabbitMqManagementClient;
+import com.google.common.collect.ImmutableMap;
+import com.rabbitmq.http.client.domain.ExchangeInfo;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyzerInfoContributorTest {
+
+  @Mock
+  private RabbitMqManagementClient managementClient;
+
+  @InjectMocks
+  private AnalyzerInfoContributor contributor;
+
+  @Test
+  void contributeShouldMarkAnalyzerAvailableWhenExchangeHasActiveConsumers() {
+    // given
+    ExchangeInfo exchange = analyzerExchange();
+    when(managementClient.getAnalyzerExchangesInfo()).thenReturn(List.of(exchange));
+    when(managementClient.getExchangesWithActiveConsumers()).thenReturn(Set.of("analyzer"));
+
+    // when
+    Set<Map<String, Object>> analyzers = (Set<Map<String, Object>>) contributor.contribute().get("analyzers");
+    assertEquals(1, analyzers.size());
+    Map<String, Object> analyzer = analyzers.iterator().next();
+
+    // then
+    assertEquals("5.15.5", analyzer.get("version"));
+    assertEquals(true, analyzer.get(AVAILABLE_KEY));
+  }
+
+  @Test
+  void contributeShouldMarkAnalyzerUnavailableWhenExchangeHasNoActiveConsumers() {
+    // given
+    ExchangeInfo exchange = analyzerExchange();
+    when(managementClient.getAnalyzerExchangesInfo()).thenReturn(List.of(exchange));
+    when(managementClient.getExchangesWithActiveConsumers()).thenReturn(Set.of());
+
+    // when
+    Set<Map<String, Object>> analyzers = (Set<Map<String, Object>>) contributor.contribute().get("analyzers");
+    assertEquals(1, analyzers.size());
+    Map<String, Object> analyzer = analyzers.iterator().next();
+
+    // then
+    assertEquals("5.15.5", analyzer.get("version"));
+    assertEquals(false, analyzer.get(AVAILABLE_KEY));
+  }
+
+  private static ExchangeInfo analyzerExchange() {
+    ExchangeInfo exchange = new ExchangeInfo();
+    exchange.setName("analyzer");
+    exchange.setArguments(ImmutableMap.of("analyzer", "analyzer", "version", "5.15.5"));
+    return exchange;
+  }
+
+}

--- a/src/test/java/com/epam/reportportal/base/info/AnalyzerInfoContributorTest.java
+++ b/src/test/java/com/epam/reportportal/base/info/AnalyzerInfoContributorTest.java
@@ -16,7 +16,6 @@
 
 package com.epam.reportportal.base.info;
 
-import static com.epam.reportportal.base.info.AnalyzerInfoContributor.AVAILABLE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -55,7 +54,7 @@ class AnalyzerInfoContributorTest {
 
     // then
     assertEquals("5.15.5", analyzer.get("version"));
-    assertEquals(true, analyzer.get(AVAILABLE_KEY));
+    assertEquals(true, analyzer.get("available"));
   }
 
   @Test
@@ -72,7 +71,7 @@ class AnalyzerInfoContributorTest {
 
     // then
     assertEquals("5.15.5", analyzer.get("version"));
-    assertEquals(false, analyzer.get(AVAILABLE_KEY));
+    assertEquals(false, analyzer.get("available"));
   }
 
   private static ExchangeInfo analyzerExchange() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analyzer information now includes an availability status, indicating whether each analyzer has active consumers.
  * Availability is determined from currently active message consumers and accurately distinguishes connected, disconnected, and unbound analyzers.

* **Tests**
  * Added coverage for analyzer availability reporting and RabbitMQ consumer and binding scenarios.
  * Improved validation of error handling when exchange information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->