### PR TITLE
Add OAuth2 (client-credentials) authorization for the Email Server integration

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/integration/util/EmailServerIntegrationService.java
+++ b/src/main/java/com/epam/reportportal/base/core/integration/util/EmailServerIntegrationService.java
@@ -28,7 +28,9 @@ import com.epam.reportportal.base.infrastructure.persistence.entity.integration.
 import com.epam.reportportal.base.infrastructure.rules.commons.validation.BusinessRule;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.model.integration.IntegrationRQ;
+import com.epam.reportportal.base.util.email.EmailAuthMode;
 import com.epam.reportportal.base.util.email.MailServiceFactory;
+import com.epam.reportportal.base.util.email.OAuth2EmailSettings;
 import com.google.common.collect.Maps;
 import jakarta.mail.MessagingException;
 import java.util.Map;
@@ -36,6 +38,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.springframework.stereotype.Service;
@@ -104,21 +107,58 @@ public class EmailServerIntegrationService extends BasicIntegrationServiceImpl {
         .ifPresent(
             username -> resultParams.put(EmailSettingsEnum.USERNAME.getAttribute(), username));
 
-    ofNullable(integrationParams.get(EmailSettingsEnum.AUTH_ENABLED.getAttribute()))
-        .ifPresent(
-            authEnabledAttribute -> {
-              boolean isAuthEnabled = BooleanUtils.toBoolean(String.valueOf(authEnabledAttribute));
-              if (isAuthEnabled) {
-                EmailSettingsEnum.PASSWORD
-                    .getAttribute(integrationParams)
-                    .ifPresent(password ->
-                        resultParams.put(EmailSettingsEnum.PASSWORD.getAttribute(), password));
-              } else {
-                /* Auto-drop values on switched-off authentication */
-                resultParams.put(EmailSettingsEnum.PASSWORD.getAttribute(), null);
-              }
-              resultParams.put(EmailSettingsEnum.AUTH_ENABLED.getAttribute(), isAuthEnabled);
-            });
+    boolean authKeyProvided = integrationParams.containsKey(OAuth2EmailSettings.AUTH_MODE.getAttribute())
+        || integrationParams.containsKey(EmailSettingsEnum.AUTH_ENABLED.getAttribute());
+    if (authKeyProvided) {
+      EmailAuthMode authMode = EmailAuthMode.resolve(integrationParams);
+      resultParams.put(OAuth2EmailSettings.AUTH_MODE.getAttribute(), authMode.name());
+      /* Kept for older clients still reading the legacy boolean flag. */
+      resultParams.put(EmailSettingsEnum.AUTH_ENABLED.getAttribute(), authMode != EmailAuthMode.OFF);
+
+      switch (authMode) {
+        case BASIC:
+          EmailSettingsEnum.PASSWORD
+              .getAttribute(integrationParams)
+              .ifPresent(
+                  password -> resultParams.put(EmailSettingsEnum.PASSWORD.getAttribute(), password));
+          /* Auto-drop the other mode's secret so it never lingers on a switched-away integration. */
+          resultParams.put(OAuth2EmailSettings.CLIENT_SECRET.getAttribute(), null);
+          break;
+        case OAUTH2:
+          BusinessRule.expect(
+                  EmailSettingsEnum.USERNAME.getAttribute(integrationParams).orElse(null),
+                  StringUtils::isNotBlank)
+              .verify(ErrorType.INCORRECT_REQUEST, "'Username' is required for OAuth2 authorization.");
+          BusinessRule.expect(
+                  OAuth2EmailSettings.TENANT_ID.getAttribute(integrationParams).orElse(null),
+                  StringUtils::isNotBlank)
+              .verify(ErrorType.INCORRECT_REQUEST, "'Tenant Id' is required for OAuth2 authorization.");
+          BusinessRule.expect(
+                  OAuth2EmailSettings.CLIENT_ID.getAttribute(integrationParams).orElse(null),
+                  StringUtils::isNotBlank)
+              .verify(ErrorType.INCORRECT_REQUEST, "'Client Id' is required for OAuth2 authorization.");
+          BusinessRule.expect(
+                  OAuth2EmailSettings.CLIENT_SECRET.getAttribute(integrationParams).orElse(null),
+                  StringUtils::isNotBlank)
+              .verify(ErrorType.INCORRECT_REQUEST, "'Client Secret' is required for OAuth2 authorization.");
+
+          OAuth2EmailSettings.TENANT_ID.getAttribute(integrationParams)
+              .ifPresent(attr -> resultParams.put(OAuth2EmailSettings.TENANT_ID.getAttribute(), attr));
+          OAuth2EmailSettings.CLIENT_ID.getAttribute(integrationParams)
+              .ifPresent(attr -> resultParams.put(OAuth2EmailSettings.CLIENT_ID.getAttribute(), attr));
+          OAuth2EmailSettings.CLIENT_SECRET.getAttribute(integrationParams)
+              .ifPresent(attr -> resultParams.put(OAuth2EmailSettings.CLIENT_SECRET.getAttribute(), attr));
+          /* Auto-drop the other mode's secret so it never lingers on a switched-away integration. */
+          resultParams.put(EmailSettingsEnum.PASSWORD.getAttribute(), null);
+          break;
+        case OFF:
+        default:
+          /* Auto-drop both modes' secrets when authorization is switched off. */
+          resultParams.put(EmailSettingsEnum.PASSWORD.getAttribute(), null);
+          resultParams.put(OAuth2EmailSettings.CLIENT_SECRET.getAttribute(), null);
+          break;
+      }
+    }
 
     EmailSettingsEnum.STAR_TLS_ENABLED
         .getAttribute(integrationParams)
@@ -185,10 +225,7 @@ public class EmailServerIntegrationService extends BasicIntegrationServiceImpl {
   }
 
   private void sendConnectionTestEmail(Integration integration, boolean isNewIntegration) {
-    boolean isAuthEnabled = BooleanUtils.toBoolean(
-        EmailSettingsEnum.AUTH_ENABLED
-            .getAttribute(integration.getParams().getParams())
-            .orElse("false"));
+    boolean isAuthEnabled = EmailAuthMode.resolve(integration.getParams().getParams()) != EmailAuthMode.OFF;
     emailServiceFactory.getEmailService(integration).ifPresent(emailService -> {
       if (isAuthEnabled) {
         try {

--- a/src/main/java/com/epam/reportportal/base/util/email/EmailAuthMode.java
+++ b/src/main/java/com/epam/reportportal/base/util/email/EmailAuthMode.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.util.email;
+
+import com.epam.reportportal.base.infrastructure.persistence.entity.EmailSettingsEnum;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Authorization mode for the email server integration ({@link OAuth2EmailSettings#AUTH_MODE}).
+ *
+ * <p>{@code EmailSettingsEnum} itself lives in the external {@code commons-dao} dependency and
+ * can't be extended with new constants here, so the new OAuth2 fields are plain string keys
+ * ({@link OAuth2EmailSettings}) instead of enum values. For backward compatibility with
+ * integrations persisted before this existed, {@link #resolve(Map)} falls back to the legacy
+ * {@link EmailSettingsEnum#AUTH_ENABLED} boolean flag when {@code authMode} is absent:
+ * {@code authEnabled=true} resolves to {@link #BASIC}, anything else resolves to {@link #OFF}.
+ */
+public enum EmailAuthMode {
+
+  OFF,
+  BASIC,
+  OAUTH2;
+
+  public static Optional<EmailAuthMode> findByName(String name) {
+    return Optional.ofNullable(name)
+        .flatMap(n -> Arrays.stream(values()).filter(it -> it.name().equalsIgnoreCase(n)).findAny());
+  }
+
+  public static EmailAuthMode resolve(Map<String, Object> params) {
+    return OAuth2EmailSettings.AUTH_MODE.getAttribute(params)
+        .flatMap(EmailAuthMode::findByName)
+        .orElseGet(() -> EmailSettingsEnum.AUTH_ENABLED.getAttribute(params)
+            .map(Boolean::parseBoolean)
+            .filter(Boolean::booleanValue)
+            .map(legacy -> BASIC)
+            .orElse(OFF));
+  }
+
+}

--- a/src/main/java/com/epam/reportportal/base/util/email/MailServiceFactory.java
+++ b/src/main/java/com/epam/reportportal/base/util/email/MailServiceFactory.java
@@ -63,15 +63,18 @@ public class MailServiceFactory {
   private final BasicTextEncryptor encryptor;
   private final IntegrationRepository integrationRepository;
   private final IntegrationTypeRepository integrationTypeRepository;
+  private final MicrosoftOAuth2TokenService oAuth2TokenService;
 
   @Autowired
   public MailServiceFactory(TemplateEngine templateEngine, BasicTextEncryptor encryptor,
       IntegrationRepository integrationRepository,
-      IntegrationTypeRepository integrationTypeRepository) {
+      IntegrationTypeRepository integrationTypeRepository,
+      MicrosoftOAuth2TokenService oAuth2TokenService) {
     this.templateEngine = templateEngine;
     this.encryptor = encryptor;
     this.integrationRepository = integrationRepository;
     this.integrationTypeRepository = integrationTypeRepository;
+    this.oAuth2TokenService = oAuth2TokenService;
   }
 
   /**
@@ -93,10 +96,8 @@ public class MailServiceFactory {
 
     if (MapUtils.isNotEmpty(config)) {
 
-      boolean authRequired = ofNullable(
-          config.get(EmailSettingsEnum.AUTH_ENABLED.getAttribute())).map(
-          e -> BooleanUtils.toBoolean(
-              String.valueOf(e))).orElse(false);
+      EmailAuthMode authMode = EmailAuthMode.resolve(config);
+      boolean authRequired = authMode != EmailAuthMode.OFF;
 
       Properties javaMailProperties = new Properties();
       javaMailProperties.put("mail.smtp.timeout", 20000);
@@ -118,6 +119,13 @@ public class MailServiceFactory {
         javaMailProperties.put("mail.smtp.ssl.checkserveridentity", true);
       }
 
+      if (authMode == EmailAuthMode.OAUTH2) {
+        /* Force XOAUTH2: the "password" JavaMail sends is the bearer access token, not a secret. */
+        javaMailProperties.put("mail.smtp.auth.mechanisms", "XOAUTH2");
+        javaMailProperties.put("mail.smtp.auth.login.disable", "true");
+        javaMailProperties.put("mail.smtp.auth.plain.disable", "true");
+      }
+
       EmailService service = new EmailService(javaMailProperties);
       service.setTemplateEngine(templateEngine);
 
@@ -128,16 +136,47 @@ public class MailServiceFactory {
           .orElse(25));
       EmailSettingsEnum.PROTOCOL.getAttribute(config).ifPresent(service::setProtocol);
       EmailSettingsEnum.FROM.getAttribute(config).ifPresent(service::setFrom);
-      if (authRequired) {
-        EmailSettingsEnum.USERNAME.getAttribute(config).ifPresent(service::setUsername);
-        EmailSettingsEnum.PASSWORD.getAttribute(config)
-            .ifPresent(password -> service.setPassword(encryptor.decrypt(password)));
+
+      switch (authMode) {
+        case BASIC:
+          EmailSettingsEnum.USERNAME.getAttribute(config).ifPresent(service::setUsername);
+          EmailSettingsEnum.PASSWORD.getAttribute(config)
+              .ifPresent(password -> service.setPassword(encryptor.decrypt(password)));
+          break;
+        case OAUTH2:
+          applyOAuth2Credentials(service, config);
+          break;
+        case OFF:
+        default:
+          break;
       }
       return Optional.of(service);
 
     }
 
     return Optional.empty();
+  }
+
+  /**
+   * Acquires an OAuth2 access token for the integration's Entra app registration and wires it into
+   * the {@link EmailService} the same way a basic-auth password would be: username stays the
+   * mailbox address, the "password" JavaMail sends over XOAUTH2 is the bearer token.
+   */
+  private void applyOAuth2Credentials(EmailService service, Map<String, Object> config) {
+    String tenantId = OAuth2EmailSettings.TENANT_ID.getAttribute(config)
+        .orElseThrow(() -> emailConfigurationFail(null));
+    String clientId = OAuth2EmailSettings.CLIENT_ID.getAttribute(config)
+        .orElseThrow(() -> emailConfigurationFail(null));
+    String clientSecret = OAuth2EmailSettings.CLIENT_SECRET.getAttribute(config)
+        .map(encryptor::decrypt)
+        .orElseThrow(() -> emailConfigurationFail(null));
+    String mailbox = EmailSettingsEnum.USERNAME.getAttribute(config)
+        .orElseThrow(() -> emailConfigurationFail(null));
+
+    String accessToken = oAuth2TokenService.getAccessToken(tenantId, clientId, clientSecret);
+
+    service.setUsername(mailbox);
+    service.setPassword(accessToken);
   }
 
   /**

--- a/src/main/java/com/epam/reportportal/base/util/email/MicrosoftOAuth2TokenService.java
+++ b/src/main/java/com/epam/reportportal/base/util/email/MicrosoftOAuth2TokenService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.util.email;
+
+/**
+ * Acquires SMTP (XOAUTH2) access tokens for a Microsoft Entra ID app registration using the
+ * client-credentials grant (application permissions, e.g. {@code SMTP.SendAsApp}), so RP's Email
+ * Server integration can authenticate to Exchange Online without basic auth.
+ *
+ * @author ReportPortal
+ */
+public interface MicrosoftOAuth2TokenService {
+
+  /**
+   * Returns a valid access token for the given app registration, reusing a cached token until it
+   * is close to expiry and transparently refreshing it otherwise.
+   *
+   * @param tenantId     Entra tenant id
+   * @param clientId     Entra app registration (client) id
+   * @param clientSecret Entra app registration client secret
+   * @return a bearer access token, scoped to {@code https://outlook.office365.com/.default}
+   */
+  String getAccessToken(String tenantId, String clientId, String clientSecret);
+
+}

--- a/src/main/java/com/epam/reportportal/base/util/email/MicrosoftOAuth2TokenServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/util/email/MicrosoftOAuth2TokenServiceImpl.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.util.email;
+
+import static com.epam.reportportal.base.infrastructure.rules.exception.ErrorType.EMAIL_CONFIGURATION_IS_INCORRECT;
+
+import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * {@link MicrosoftOAuth2TokenService} backed by the Microsoft identity platform's
+ * {@code client_credentials} grant against {@code https://login.microsoftonline.com}.
+ *
+ * <p>Tokens are cached in memory per (tenant, client, secret) triple and refreshed a short margin
+ * before they expire, so a burst of outgoing emails does not trigger a token request per message.
+ *
+ * @author ReportPortal
+ */
+@Service
+public class MicrosoftOAuth2TokenServiceImpl implements MicrosoftOAuth2TokenService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MicrosoftOAuth2TokenServiceImpl.class);
+
+  private static final String TOKEN_ENDPOINT_FORMAT =
+      "https://login.microsoftonline.com/%s/oauth2/v2.0/token";
+  private static final String SCOPE = "https://outlook.office365.com/.default";
+  /* Refresh this many seconds before the token's real expiry to avoid using an expired token. */
+  private static final long EXPIRY_MARGIN_SECONDS = 60L;
+
+  private final RestTemplate restTemplate;
+  private final ConcurrentHashMap<String, CachedToken> cache = new ConcurrentHashMap<>();
+
+  public MicrosoftOAuth2TokenServiceImpl(RestTemplate restTemplate) {
+    this.restTemplate = restTemplate;
+  }
+
+  @Override
+  public String getAccessToken(String tenantId, String clientId, String clientSecret) {
+    String cacheKey = cacheKey(tenantId, clientId, clientSecret);
+    CachedToken cached = cache.get(cacheKey);
+    if (cached != null && cached.isValid()) {
+      return cached.accessToken;
+    }
+    CachedToken fresh = requestToken(tenantId, clientId, clientSecret);
+    cache.put(cacheKey, fresh);
+    return fresh.accessToken;
+  }
+
+  private CachedToken requestToken(String tenantId, String clientId, String clientSecret) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("grant_type", "client_credentials");
+    body.add("client_id", clientId);
+    body.add("client_secret", clientSecret);
+    body.add("scope", SCOPE);
+
+    String url = String.format(TOKEN_ENDPOINT_FORMAT, tenantId);
+    try {
+      TokenResponse response = restTemplate.postForObject(url, new HttpEntity<>(body, headers),
+          TokenResponse.class);
+      if (response == null || response.accessToken == null) {
+        throw new ReportPortalException(EMAIL_CONFIGURATION_IS_INCORRECT,
+            "Microsoft identity platform returned an empty token response.");
+      }
+      long expiresInSeconds = response.expiresIn != null ? response.expiresIn : 0L;
+      Instant expiresAt = Instant.now().plusSeconds(Math.max(0, expiresInSeconds - EXPIRY_MARGIN_SECONDS));
+      return new CachedToken(response.accessToken, expiresAt);
+    } catch (RestClientException e) {
+      LOGGER.error("Unable to acquire an OAuth2 access token for the email server integration", e);
+      throw new ReportPortalException(EMAIL_CONFIGURATION_IS_INCORRECT,
+          "Unable to acquire an OAuth2 access token. Please check the tenant id, client id and "
+              + "client secret of the email server integration. " + e.getMessage());
+    }
+  }
+
+  private static String cacheKey(String tenantId, String clientId, String clientSecret) {
+    return tenantId + '|' + clientId + '|' + Objects.hashCode(clientSecret);
+  }
+
+  private static final class CachedToken {
+
+    private final String accessToken;
+    private final Instant expiresAt;
+
+    private CachedToken(String accessToken, Instant expiresAt) {
+      this.accessToken = accessToken;
+      this.expiresAt = expiresAt;
+    }
+
+    private boolean isValid() {
+      return Instant.now().isBefore(expiresAt);
+    }
+  }
+
+  /* Package-private (not private) so the test class in this same package can build instances directly. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static final class TokenResponse {
+
+    @JsonProperty("access_token")
+    String accessToken;
+
+    @JsonProperty("expires_in")
+    Long expiresIn;
+
+    TokenResponse() {
+    }
+
+    TokenResponse(String accessToken, Long expiresIn) {
+      this.accessToken = accessToken;
+      this.expiresIn = expiresIn;
+    }
+  }
+
+}

--- a/src/main/java/com/epam/reportportal/base/util/email/OAuth2EmailSettings.java
+++ b/src/main/java/com/epam/reportportal/base/util/email/OAuth2EmailSettings.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.util.email;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Additional email server integration parameter keys for OAuth2 authorization, kept outside
+ * {@code EmailSettingsEnum} because that enum lives in the external {@code commons-dao}
+ * dependency and can't be extended from this repository.
+ */
+public enum OAuth2EmailSettings {
+
+  AUTH_MODE("authMode"),
+  TENANT_ID("tenantId"),
+  CLIENT_ID("clientId"),
+  CLIENT_SECRET("clientSecret");
+
+  private final String attribute;
+
+  OAuth2EmailSettings(String attribute) {
+    this.attribute = attribute;
+  }
+
+  public String getAttribute() {
+    return attribute;
+  }
+
+  public Optional<String> getAttribute(Map<String, Object> params) {
+    return Optional.ofNullable(params.get(attribute)).map(String::valueOf);
+  }
+
+}

--- a/src/test/java/com/epam/reportportal/base/util/email/EmailAuthModeTest.java
+++ b/src/test/java/com/epam/reportportal/base/util/email/EmailAuthModeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.util.email;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.epam.reportportal.base.infrastructure.persistence.entity.EmailSettingsEnum;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author ReportPortal
+ */
+class EmailAuthModeTest {
+
+  @Test
+  void findByNameIsCaseInsensitive() {
+    assertEquals(EmailAuthMode.OAUTH2, EmailAuthMode.findByName("oauth2").orElseThrow());
+    assertEquals(EmailAuthMode.BASIC, EmailAuthMode.findByName("Basic").orElseThrow());
+    assertFalse(EmailAuthMode.findByName("noSuchMode").isPresent());
+    assertFalse(EmailAuthMode.findByName(null).isPresent());
+  }
+
+  @Test
+  void resolveUsesAuthModeWhenPresent() {
+    Map<String, Object> params = Map.of(
+        OAuth2EmailSettings.AUTH_MODE.getAttribute(), "OAUTH2",
+        EmailSettingsEnum.AUTH_ENABLED.getAttribute(), false
+    );
+
+    assertEquals(EmailAuthMode.OAUTH2, EmailAuthMode.resolve(params));
+  }
+
+  /**
+   * Every Email Server integration persisted before this enum existed only has the legacy boolean
+   * {@code authEnabled} flag. It must keep resolving to exactly the mode it behaved as before.
+   */
+  @Test
+  void resolveFallsBackToLegacyAuthEnabledWhenAuthModeAbsent() {
+    assertEquals(EmailAuthMode.BASIC,
+        EmailAuthMode.resolve(Map.of(EmailSettingsEnum.AUTH_ENABLED.getAttribute(), true)));
+    assertEquals(EmailAuthMode.BASIC,
+        EmailAuthMode.resolve(Map.of(EmailSettingsEnum.AUTH_ENABLED.getAttribute(), "true")));
+    assertEquals(EmailAuthMode.OFF,
+        EmailAuthMode.resolve(Map.of(EmailSettingsEnum.AUTH_ENABLED.getAttribute(), false)));
+  }
+
+  @Test
+  void resolveDefaultsToOffWhenNeitherKeyIsPresent() {
+    assertEquals(EmailAuthMode.OFF, EmailAuthMode.resolve(Map.of()));
+  }
+
+  @Test
+  void allValuesAreCoveredByFindByName() {
+    for (EmailAuthMode mode : EmailAuthMode.values()) {
+      assertTrue(EmailAuthMode.findByName(mode.name()).isPresent());
+    }
+  }
+
+}

--- a/src/test/java/com/epam/reportportal/base/util/email/MailServiceFactoryTest.java
+++ b/src/test/java/com/epam/reportportal/base/util/email/MailServiceFactoryTest.java
@@ -62,6 +62,9 @@ class MailServiceFactoryTest {
   @Mock
   private IntegrationTypeRepository integrationTypeRepository;
 
+  @Mock
+  private MicrosoftOAuth2TokenService oAuth2TokenService;
+
   private Integration integration = mock(Integration.class);
 
   private IntegrationType integrationType = mock(IntegrationType.class);
@@ -79,7 +82,7 @@ class MailServiceFactoryTest {
     basicTextEncryptor = new BasicTextEncryptor();
     basicTextEncryptor.setPassword("123");
     mailServiceFactory = new MailServiceFactory(templateEngine, basicTextEncryptor,
-        integrationRepository, integrationTypeRepository);
+        integrationRepository, integrationTypeRepository, oAuth2TokenService);
   }
 
   @Test
@@ -194,6 +197,53 @@ class MailServiceFactoryTest {
     String sslClass = (String) javaMailProperties.get("mail.smtp.socketFactory.class");
     Assertions.assertEquals("javax.net.ssl.SSLSocketFactory", sslClass);
 
+  }
+
+  @Test
+  void shouldReturnEmailServiceWithOAuth2WhenEnabled() {
+
+    Map<String, Object> config = ImmutableMap.<String, Object>builder()
+        .put(OAuth2EmailSettings.AUTH_MODE.getAttribute(), "OAUTH2")
+        .put(EmailSettingsEnum.USERNAME.getAttribute(), "notifications@example.com")
+        .put(OAuth2EmailSettings.TENANT_ID.getAttribute(), "tenant-id")
+        .put(OAuth2EmailSettings.CLIENT_ID.getAttribute(), "client-id")
+        .put(OAuth2EmailSettings.CLIENT_SECRET.getAttribute(), basicTextEncryptor.encrypt("client-secret"))
+        .build();
+
+    when(integration.isEnabled()).thenReturn(true);
+    when(integration.getParams()).thenReturn(integrationParams);
+    when(integrationParams.getParams()).thenReturn(config);
+    when(oAuth2TokenService.getAccessToken("tenant-id", "client-id", "client-secret"))
+        .thenReturn("mock-access-token");
+
+    Optional<EmailService> emailService = mailServiceFactory.getEmailService(integration);
+
+    Assertions.assertTrue(emailService.isPresent());
+
+    EmailService service = emailService.get();
+
+    Assertions.assertEquals("notifications@example.com", service.getUsername());
+    Assertions.assertEquals("mock-access-token", service.getPassword());
+    Properties javaMailProperties = service.getJavaMailProperties();
+    Assertions.assertEquals("XOAUTH2", javaMailProperties.get("mail.smtp.auth.mechanisms"));
+  }
+
+  @Test
+  void shouldFailWhenOAuth2UsernameIsMissing() {
+
+    Map<String, Object> config = ImmutableMap.<String, Object>builder()
+        .put(OAuth2EmailSettings.AUTH_MODE.getAttribute(), "OAUTH2")
+        .put(OAuth2EmailSettings.TENANT_ID.getAttribute(), "tenant-id")
+        .put(OAuth2EmailSettings.CLIENT_ID.getAttribute(), "client-id")
+        .put(OAuth2EmailSettings.CLIENT_SECRET.getAttribute(), basicTextEncryptor.encrypt("client-secret"))
+        .build();
+
+    when(integration.isEnabled()).thenReturn(true);
+    when(integration.getParams()).thenReturn(integrationParams);
+    when(integrationParams.getParams()).thenReturn(config);
+
+    assertThrows(ReportPortalException.class,
+        () -> mailServiceFactory.getEmailService(integration));
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/util/email/MicrosoftOAuth2TokenServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/util/email/MicrosoftOAuth2TokenServiceImplTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.util.email;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
+import com.epam.reportportal.base.util.email.MicrosoftOAuth2TokenServiceImpl.TokenResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author ReportPortal
+ */
+class MicrosoftOAuth2TokenServiceImplTest {
+
+  private RestTemplate restTemplate;
+  private MicrosoftOAuth2TokenServiceImpl tokenService;
+
+  @BeforeEach
+  void setUp() {
+    restTemplate = mock(RestTemplate.class);
+    tokenService = new MicrosoftOAuth2TokenServiceImpl(restTemplate);
+  }
+
+  @Test
+  void shouldReturnAccessTokenFromTokenEndpoint() {
+
+    when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(
+        new TokenResponse("access-token-1", 3600L));
+
+    String token = tokenService.getAccessToken("tenant", "client", "secret");
+
+    assertEquals("access-token-1", token);
+  }
+
+  @Test
+  void shouldCacheTokenUntilExpiry() {
+
+    when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(
+        new TokenResponse("access-token-1", 3600L));
+
+    String first = tokenService.getAccessToken("tenant", "client", "secret");
+    String second = tokenService.getAccessToken("tenant", "client", "secret");
+
+    assertEquals("access-token-1", first);
+    assertEquals("access-token-1", second);
+    verify(restTemplate, times(1)).postForObject(anyString(), any(), any());
+  }
+
+  @Test
+  void shouldRequestNewTokenWhenAlreadyExpired() {
+
+    when(restTemplate.postForObject(anyString(), any(), any()))
+        .thenReturn(new TokenResponse("access-token-1", 0L))
+        .thenReturn(new TokenResponse("access-token-2", 3600L));
+
+    String first = tokenService.getAccessToken("tenant", "client", "secret");
+    String second = tokenService.getAccessToken("tenant", "client", "secret");
+
+    assertEquals("access-token-1", first);
+    assertEquals("access-token-2", second);
+    verify(restTemplate, times(2)).postForObject(anyString(), any(), any());
+  }
+
+  @Test
+  void shouldRequestSeparateTokensForDifferentCredentials() {
+
+    when(restTemplate.postForObject(anyString(), any(), any()))
+        .thenReturn(new TokenResponse("token-for-client-a", 3600L))
+        .thenReturn(new TokenResponse("token-for-client-b", 3600L));
+
+    String tokenA = tokenService.getAccessToken("tenant", "client-a", "secret");
+    String tokenB = tokenService.getAccessToken("tenant", "client-b", "secret");
+
+    assertEquals("token-for-client-a", tokenA);
+    assertEquals("token-for-client-b", tokenB);
+  }
+
+  @Test
+  void shouldWrapRestClientExceptionAsReportPortalException() {
+
+    when(restTemplate.postForObject(anyString(), any(), any()))
+        .thenThrow(new RestClientException("invalid_client"));
+
+    assertThrows(ReportPortalException.class,
+        () -> tokenService.getAccessToken("tenant", "client", "wrong-secret"));
+  }
+
+  @Test
+  void shouldFailWhenTokenResponseHasNoAccessToken() {
+
+    when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(
+        new TokenResponse(null, 3600L));
+
+    assertThrows(ReportPortalException.class,
+        () -> tokenService.getAccessToken("tenant", "client", "secret"));
+  }
+
+}


### PR DESCRIPTION
Add OAuth2 (client-credentials) authorization for the Email Server integration

## Summary

The built-in Email Server integration currently supports Basic auth only (`authEnabled: true/false` + username/password). Microsoft has permanently disabled Basic Auth for SMTP AUTH on Exchange Online, so any RP instance whose SMTP provider is Microsoft 365/Exchange Online can no longer authenticate at all - the only way to still use a Microsoft-hosted mailbox today is to build/host a separate SMTP relay in front of RP.

This PR adds a third authorization mode, `OAUTH2`, alongside the existing `BASIC`/off states, using the OAuth2 **client-credentials** grant (application permissions, e.g. Exchange Online's `SMTP.SendAsApp`) against the Microsoft identity platform. This is the standard app-only auth pattern for a headless service like RP - no user sign-in, no delegated consent, no refresh-token lifecycle to manage.

## What's new

- `EmailAuthMode` - `OFF` / `BASIC` / `OAUTH2`. `resolve(params)` falls back to the legacy boolean `authEnabled` flag when the new `authMode` key is absent, so every integration created before this change keeps working unmodified (see "Backward compatibility" below).
- `OAuth2EmailSettings` - the three new param keys (`tenantId`, `clientId`, `clientSecret`) plus `authMode`, kept as plain constants alongside the existing `EmailSettingsEnum` rather than added to it, since that enum lives in `commons-dao` and isn't something this repo can extend on its own. (Happy to move these into `commons-dao` proper if that's the preferred home - flagging it here rather than assuming.)
- `MicrosoftOAuth2TokenService` / `MicrosoftOAuth2TokenServiceImpl` - acquires an access token via the `client_credentials` grant against `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token`, scope `https://outlook.office365.com/.default`. Tokens are cached in memory per (tenant, client, secret) and refreshed a short margin before expiry, so a burst of outgoing notification emails doesn't trigger a token request per message.
- `MailServiceFactory` - when `authMode == OAUTH2`, configures `mail.smtp.auth.mechanisms=XOAUTH2` (disabling LOGIN/PLAIN so the mechanism can't silently fall back to sending the access token as a plaintext password) and uses the integration's `Username` field as the SMTP identity with the fetched access token as the "password". `jakarta.mail` (already a dependency) supports XOAUTH2 natively - no new mail library needed.
- `EmailServerIntegrationService` - validates the four new required fields for `OAUTH2` mode, encrypts `clientSecret` at rest exactly like `password` already is, and auto-drops the other mode's secret when an integration is switched between Basic/OAuth2/Off so a stale secret never lingers on a saved integration.

## Backward compatibility

No migration, no schema change - `Integration.params` is a schemaless JSONB map, and the new keys are additive. The one behavior that needed explicit protection: `EmailAuthMode.resolve()` treats a missing `authMode` key as "read the legacy `authEnabled` boolean instead," so an integration saved by the pre-this-PR code continues to resolve to exactly the mode it behaved as before. Verified concretely, not just by code inspection: saved an integration with genuinely unmodified code, then loaded and re-saved it with this patch applied - zero data loss, correct normalization to the new shape, connection still succeeds.

## Testing

- Unit tests extended/added for all new/changed classes (`MailServiceFactoryTest`, `EmailServerIntegrationServiceTest`, new `EmailAuthModeTest`, new `MicrosoftOAuth2TokenServiceImplTest` - the latter mocks `RestTemplate` directly, no new test dependency).
- Live end-to-end verification against a real Microsoft 365 tenant and mailbox using an Entra app registration with the `SMTP.SendAsApp` application permission: real `235 2.7.0 Authentication successful` from Exchange Online, both for a fresh `OAUTH2`-mode integration and for RP's own "send test email" connection check.
- Live end-to-end verification that an existing Basic-auth (Gmail) integration is unaffected by this change, before and after upgrade.

## Notes for reviewers

- This pairs with a [service-ui PR](https://github.com/reportportal/service-ui/pull/5695)  - the backend alone is usable via direct API calls without the UI change, but the UI change is what makes it usable through the product.
- Open question I'd like input on: should `tenantId`/`clientId`/`clientSecret` live as new constants in `commons-dao`'s `EmailSettingsEnum` instead of a local `OAuth2EmailSettings`? I kept them local specifically to avoid a cross-repo PR dependency for review, but can move them if that's preferred.
