### PR TITLE
EPMRPP-118950 || Fix NPE & revoke token when admin rights revoked

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/auth/TokenBlacklistService.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/TokenBlacklistService.java
@@ -16,6 +16,7 @@
 
 package com.epam.reportportal.base.core.auth;
 
+import com.epam.reportportal.base.infrastructure.persistence.entity.user.User;
 import java.time.Instant;
 
 /**
@@ -37,6 +38,13 @@ public interface TokenBlacklistService {
    * @param subject JWT subject ({@code sub} claim) — typically the user's login or external id
    */
   void revokeSubject(String subject);
+
+  /**
+   * Revokes every currently active JWT issued to the given user, by login and external id (if present).
+   *
+   * @param user the user whose tokens should be revoked
+   */
+  void revokeUserTokens(User user);
 
   /**
    * Checks whether a JWT identified by the given parameters has been revoked, either directly by {@code jti} or by a

--- a/src/main/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImpl.java
@@ -19,6 +19,7 @@ package com.epam.reportportal.base.core.auth.impl;
 import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.RevokedToken;
+import com.epam.reportportal.base.infrastructure.persistence.entity.user.User;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -53,6 +54,15 @@ public class TokenBlacklistServiceImpl implements TokenBlacklistService {
       throw new IllegalArgumentException("subject must not be blank");
     }
     revokedTokenRepository.save(RevokedToken.forSubject(subject));
+  }
+
+  @Override
+  @Transactional
+  public void revokeUserTokens(User user) {
+    revokeSubject(user.getLogin());
+    if (StringUtils.isNotBlank(user.getExternalId())) {
+      revokeSubject(user.getExternalId());
+    }
   }
 
   @Override

--- a/src/main/java/com/epam/reportportal/base/core/project/impl/OrganizationProjectHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/project/impl/OrganizationProjectHandlerImpl.java
@@ -127,9 +127,7 @@ public class OrganizationProjectHandlerImpl implements OrganizationProjectHandle
     var rpUser = getPrincipal();
     OrganizationProjectsPage organizationProjectsPage = new OrganizationProjectsPage();
 
-    if (!rpUser.getUserRole().equals(UserRole.ADMINISTRATOR)
-        && rpUser.getOrganizationDetails().get(orgId.toString()).getOrgRole()
-        .equals(OrganizationRole.MEMBER)) {
+    if (!rpUser.getUserRole().equals(UserRole.ADMINISTRATOR) && isOrganizationMember(rpUser, orgId)) {
 
       var projectIds = projectUserRepository.findProjectIdsByUserId(rpUser.getUserId())
           .stream()
@@ -166,6 +164,12 @@ public class OrganizationProjectHandlerImpl implements OrganizationProjectHandle
 
     return responseWithPageParameters(organizationProjectsPage, pageable,
         projectProfilePagedList.getTotalElements());
+  }
+
+  private boolean isOrganizationMember(ReportPortalUser rpUser, Long orgId) {
+    var orgDetails = rpUser.getOrganizationDetails().get(orgId.toString());
+    expect(orgDetails, Objects::nonNull).verify(ErrorType.ACCESS_DENIED);
+    return OrganizationRole.MEMBER.equals(orgDetails.getOrgRole());
   }
 
   @Override

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImpl.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -128,17 +127,10 @@ public class DeleteUserHandlerImpl implements DeleteUserHandler {
 
     dataStore.deleteUserPhoto(user);
     userRepository.delete(user);
-    revokeUserTokens(user);
+    tokenBlacklistService.revokeUserTokens(user);
     sendEmailAboutDeletion(user, loggedInUser);
 
     return user;
-  }
-
-  private void revokeUserTokens(User user) {
-    tokenBlacklistService.revokeSubject(user.getLogin());
-    if (StringUtils.isNotBlank(user.getExternalId())) {
-      tokenBlacklistService.revokeSubject(user.getExternalId());
-    }
   }
 
   private void sendEmailAboutDeletion(User user, ReportPortalUser loggedInUser) {

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImpl.java
@@ -24,6 +24,7 @@ import static com.epam.reportportal.base.infrastructure.rules.exception.ErrorTyp
 import static com.epam.reportportal.base.infrastructure.rules.exception.ErrorType.USER_ALREADY_EXISTS;
 import static com.epam.reportportal.base.util.email.EmailRulesValidator.NORMALIZE_EMAIL;
 
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.core.events.domain.ChangeUserTypeEvent;
 import com.epam.reportportal.base.core.user.UserMutationService;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
@@ -56,6 +57,7 @@ public class UserMutationServiceImpl implements UserMutationService {
   private final UserRepository userRepository;
   private final ProjectRepository projectRepository;
   private final ApplicationEventPublisher eventPublisher;
+  private final TokenBlacklistService tokenBlacklistService;
 
   @Override
   public void updateEmail(User user, String rawEmail, ReportPortalUser editor) {
@@ -106,11 +108,17 @@ public class UserMutationServiceImpl implements UserMutationService {
     UserRole newRole = UserRole.findByName(role)
         .orElseThrow(() -> new ReportPortalException(BAD_REQUEST_ERROR, "Incorrect specified Account Role parameter."));
 
+    UserRole oldRole = user.getRole();
+    if (oldRole == newRole) {
+      return;
+    }
+
     eventPublisher.publishEvent(
-        new ChangeUserTypeEvent(user.getId(), user.getLogin(), user.getRole(), newRole,
+        new ChangeUserTypeEvent(user.getId(), user.getLogin(), oldRole, newRole,
             editor.getUserId(), editor.getUsername()));
 
     user.setRole(newRole);
+    tokenBlacklistService.revokeUserTokens(user);
   }
 
   @Override

--- a/src/main/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImpl.java
@@ -84,7 +84,7 @@ public class UserMutationServiceImpl implements UserMutationService {
 
   @Override
   public void updateFullName(User user, String fullName, ReportPortalUser editor) {
-    expect(StringUtils.isNotBlank(fullName), Boolean.TRUE::equals)
+    expect(fullName, StringUtils::isNotBlank)
         .verify(BAD_REQUEST_ERROR, "Full name must not be empty.");
 
     expect(fullName.length() >= MIN_USER_NAME_LENGTH && fullName.length() <= MAX_USER_NAME_LENGTH,

--- a/src/main/java/com/epam/reportportal/base/util/OrganizationUserValidator.java
+++ b/src/main/java/com/epam/reportportal/base/util/OrganizationUserValidator.java
@@ -80,7 +80,8 @@ public class OrganizationUserValidator {
    * @return true if the user has a manager role, false otherwise
    */
   public static boolean isManager(ReportPortalUser user, OrganizationUser organizationUser) {
-    return user.getOrganizationDetails().get(organizationUser.getOrganization().getId().toString()).getOrgRole()
-        .equals(OrganizationRole.MANAGER);
+    var orgDetails = user.getOrganizationDetails()
+        .get(organizationUser.getOrganization().getId().toString());
+    return orgDetails != null && OrganizationRole.MANAGER.equals(orgDetails.getOrgRole());
   }
 }

--- a/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
@@ -94,26 +94,36 @@ class TokenBlacklistServiceImplTest {
   }
 
   @Test
-  @DisplayName("Should revoke tokens by user login")
-  void revokeUserTokensWhenCalledShouldRevokeLoginSubject() {
+  @DisplayName("Should revoke tokens by user login only when external id is absent")
+  void revokeUserTokensWhenExternalIdAbsentShouldRevokeLoginSubjectOnly() {
+    // Given
     var user = new User();
     user.setLogin("user@example.com");
+    var captor = ArgumentCaptor.forClass(RevokedToken.class);
 
+    // When
     service.revokeUserTokens(user);
 
-    verify(revokedTokenRepository).save(RevokedToken.forSubject("user@example.com"));
+    // Then
+    verify(revokedTokenRepository).save(captor.capture());
+    assertEquals("user@example.com", captor.getValue().getSubject());
+    assertNull(captor.getValue().getJti());
+    assertNotNull(captor.getValue().getRevokedAt());
   }
 
   @Test
   @DisplayName("Should revoke tokens by login and external id when external id is present")
   void revokeUserTokensWhenExternalIdPresentShouldRevokeBothSubjects() {
+    // Given
     var user = new User();
     user.setLogin("user@example.com");
     user.setExternalId("ext-123");
     var captor = ArgumentCaptor.forClass(RevokedToken.class);
 
+    // When
     service.revokeUserTokens(user);
 
+    // Then
     verify(revokedTokenRepository, times(2)).save(captor.capture());
     assertEquals("user@example.com", captor.getAllValues().get(0).getSubject());
     assertEquals("ext-123", captor.getAllValues().get(1).getSubject());

--- a/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/auth/impl/TokenBlacklistServiceImplTest.java
@@ -22,11 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.epam.reportportal.base.infrastructure.persistence.dao.RevokedTokenRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.RevokedToken;
+import com.epam.reportportal.base.infrastructure.persistence.entity.user.User;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -89,6 +91,32 @@ class TokenBlacklistServiceImplTest {
   @DisplayName("Should throw when subject is blank")
   void revokeSubjectWhenSubjectBlankShouldThrow() {
     assertThrows(IllegalArgumentException.class, () -> service.revokeSubject(null));
+  }
+
+  @Test
+  @DisplayName("Should revoke tokens by user login")
+  void revokeUserTokensWhenCalledShouldRevokeLoginSubject() {
+    var user = new User();
+    user.setLogin("user@example.com");
+
+    service.revokeUserTokens(user);
+
+    verify(revokedTokenRepository).save(RevokedToken.forSubject("user@example.com"));
+  }
+
+  @Test
+  @DisplayName("Should revoke tokens by login and external id when external id is present")
+  void revokeUserTokensWhenExternalIdPresentShouldRevokeBothSubjects() {
+    var user = new User();
+    user.setLogin("user@example.com");
+    user.setExternalId("ext-123");
+    var captor = ArgumentCaptor.forClass(RevokedToken.class);
+
+    service.revokeUserTokens(user);
+
+    verify(revokedTokenRepository, times(2)).save(captor.capture());
+    assertEquals("user@example.com", captor.getAllValues().get(0).getSubject());
+    assertEquals("ext-123", captor.getAllValues().get(1).getSubject());
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/DeleteUserHandlerImplTest.java
@@ -127,11 +127,11 @@ class DeleteUserHandlerImplTest {
 
     verify(repository, times(1)).findById(2L);
     verify(dataStore, times(1)).deleteUserPhoto(any());
-    verify(tokenBlacklistService).revokeSubject("test");
+    verify(tokenBlacklistService).revokeUserTokens(user);
   }
 
   @Test
-  void deleteUserWithExternalIdShouldRevokeSubjectForBothLoginAndExternalId() {
+  void deleteUserWithExternalIdShouldRevokeUserTokens() {
     User user = new User();
     user.setId(2L);
     user.setLogin("test");
@@ -152,8 +152,7 @@ class DeleteUserHandlerImplTest {
         2L, getRpUser("admin", UserRole.ADMINISTRATOR, OrganizationRole.MANAGER, ProjectRole.EDITOR,
             1L));
 
-    verify(tokenBlacklistService).revokeSubject("test");
-    verify(tokenBlacklistService).revokeSubject("ext-user-id");
+    verify(tokenBlacklistService).revokeUserTokens(user);
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImplTest.java
@@ -253,33 +253,63 @@ class UserMutationServiceImplTest {
     }
 
     @Test
-    @DisplayName("Should update role and publish event")
-    void updateInstanceRoleWhenValidShouldUpdateAndPublishEvent() {
+    @DisplayName("Should update role when role changes")
+    void updateInstanceRoleWhenRoleChangesShouldUpdateRole() {
+      // When
       userMutationService.updateInstanceRole(user, "ADMINISTRATOR", adminEditor);
 
+      // Then
       assertThat(user.getRole()).isEqualTo(UserRole.ADMINISTRATOR);
+    }
+
+    @Test
+    @DisplayName("Should publish change event when role changes")
+    void updateInstanceRoleWhenRoleChangesShouldPublishChangeUserTypeEvent() {
+      // When
+      userMutationService.updateInstanceRole(user, "ADMINISTRATOR", adminEditor);
+
+      // Then
       verify(eventPublisher).publishEvent(any(ChangeUserTypeEvent.class));
+    }
+
+    @Test
+    @DisplayName("Should revoke user tokens when role changes")
+    void updateInstanceRoleWhenRoleChangesShouldRevokeUserTokens() {
+      // When
+      userMutationService.updateInstanceRole(user, "ADMINISTRATOR", adminEditor);
+
+      // Then
       verify(tokenBlacklistService).revokeUserTokens(user);
     }
 
     @Test
-    @DisplayName("Should not publish event or revoke tokens when role is unchanged")
-    void updateInstanceRoleWhenRoleUnchangedShouldNotPublishEventOrRevokeTokens() {
+    @DisplayName("Should not change role when requested role is the same")
+    void updateInstanceRoleWhenRoleUnchangedShouldKeepRole() {
+      // When
       userMutationService.updateInstanceRole(user, "USER", adminEditor);
 
+      // Then
       assertThat(user.getRole()).isEqualTo(UserRole.USER);
-      verify(eventPublisher, never()).publishEvent(any());
-      verify(tokenBlacklistService, never()).revokeUserTokens(any());
     }
 
     @Test
-    @DisplayName("Should revoke user tokens when role changes and external id is present")
-    void updateInstanceRoleWhenExternalIdPresentShouldRevokeUserTokens() {
-      user.setExternalId("ext-123");
+    @DisplayName("Should not publish event when role is unchanged")
+    void updateInstanceRoleWhenRoleUnchangedShouldNotPublishEvent() {
+      // When
+      userMutationService.updateInstanceRole(user, "USER", adminEditor);
 
-      userMutationService.updateInstanceRole(user, "ADMINISTRATOR", adminEditor);
+      // Then
+      verify(eventPublisher, never()).publishEvent(any());
+    }
 
-      verify(tokenBlacklistService).revokeUserTokens(user);
+    @Test
+    @DisplayName("Should not revoke tokens when role is unchanged")
+    void updateInstanceRoleWhenRoleUnchangedShouldNotRevokeTokens() {
+      // When
+      userMutationService.updateInstanceRole(user, "USER", adminEditor);
+
+      // Then
+      verify(tokenBlacklistService, never()).revokeUserTokens(any());
     }
   }
 

--- a/src/test/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/user/impl/UserMutationServiceImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.epam.reportportal.base.core.auth.TokenBlacklistService;
 import com.epam.reportportal.base.core.events.domain.ChangeUserTypeEvent;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.dao.ProjectRepository;
@@ -57,6 +58,9 @@ class UserMutationServiceImplTest {
 
   @Mock
   private ApplicationEventPublisher eventPublisher;
+
+  @Mock
+  private TokenBlacklistService tokenBlacklistService;
 
   @InjectMocks
   private UserMutationServiceImpl userMutationService;
@@ -255,6 +259,27 @@ class UserMutationServiceImplTest {
 
       assertThat(user.getRole()).isEqualTo(UserRole.ADMINISTRATOR);
       verify(eventPublisher).publishEvent(any(ChangeUserTypeEvent.class));
+      verify(tokenBlacklistService).revokeUserTokens(user);
+    }
+
+    @Test
+    @DisplayName("Should not publish event or revoke tokens when role is unchanged")
+    void updateInstanceRoleWhenRoleUnchangedShouldNotPublishEventOrRevokeTokens() {
+      userMutationService.updateInstanceRole(user, "USER", adminEditor);
+
+      assertThat(user.getRole()).isEqualTo(UserRole.USER);
+      verify(eventPublisher, never()).publishEvent(any());
+      verify(tokenBlacklistService, never()).revokeUserTokens(any());
+    }
+
+    @Test
+    @DisplayName("Should revoke user tokens when role changes and external id is present")
+    void updateInstanceRoleWhenExternalIdPresentShouldRevokeUserTokens() {
+      user.setExternalId("ext-123");
+
+      userMutationService.updateInstanceRole(user, "ADMINISTRATOR", adminEditor);
+
+      verify(tokenBlacklistService).revokeUserTokens(user);
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of organization membership checks when organization details are unavailable.
  * Users without organization details or a matching organization entry are now handled safely instead of triggering errors.
  * Access is denied appropriately when required organization information is missing.
  * User access tokens are now revoked when accounts are deleted or instance roles change.
  * Unchanged roles no longer trigger unnecessary token revocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->