### PR TITLE
EPMRPP-121353 || Add dependency destruction on plugin unload

### DIFF
--- a/src/main/java/com/epam/reportportal/base/core/events/listener/PluginBroadcastPublisher.java
+++ b/src/main/java/com/epam/reportportal/base/core/events/listener/PluginBroadcastPublisher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.events.listener;
+
+import com.epam.reportportal.base.core.configs.rabbit.InternalConfiguration;
+import com.epam.reportportal.base.core.events.MessageBus;
+import com.epam.reportportal.base.core.plugin.PluginStateChangedMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Publishes {@link PluginStateChangedMessage} to the {@code broadcast.events} fanout exchange (one anonymous,
+ * auto-deleted queue per instance) after the enclosing transaction commits - mirroring {@link DomainEventPublisher}'s
+ * after-commit pattern for the same reason: publishing mid-transaction would let another instance react to a plugin
+ * change before this instance's own database write is visible to it.
+ *
+ * <p>{@code fallbackExecution = true} also fires the publishing immediately when there is no active
+ * transaction (e.g. a call site outside a {@code @Transactional} boundary).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PluginBroadcastPublisher {
+
+  private final MessageBus messageBus;
+
+  @Async(value = "eventListenerExecutor")
+  @TransactionalEventListener(fallbackExecution = true)
+  public void onPluginStateChanged(PluginStateChangedMessage message) {
+    log.debug("Broadcasting plugin state change for plugin id = '{}'", message.getPluginId());
+    messageBus.publish(InternalConfiguration.EXCHANGE_EVENTS, InternalConfiguration.KEY_EVENTS, message);
+  }
+
+}

--- a/src/main/java/com/epam/reportportal/base/core/integration/plugin/impl/CreatePluginHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/integration/plugin/impl/CreatePluginHandlerImpl.java
@@ -19,6 +19,7 @@ package com.epam.reportportal.base.core.integration.plugin.impl;
 import com.epam.reportportal.base.core.events.domain.PluginUploadedEvent;
 import com.epam.reportportal.base.core.integration.plugin.CreatePluginHandler;
 import com.epam.reportportal.base.core.integration.plugin.strategy.PluginUploaderFactory;
+import com.epam.reportportal.base.core.plugin.PluginStateChangedMessage;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.entity.integration.IntegrationType;
 import com.epam.reportportal.base.infrastructure.rules.commons.validation.BusinessRule;
@@ -81,6 +82,8 @@ public class CreatePluginHandlerImpl implements CreatePluginHandler {
       pluginActivityResource.setName(integrationType.getName());
       applicationEventPublisher.publishEvent(
           new PluginUploadedEvent(pluginActivityResource, user.getUserId(), user.getUsername()));
+      applicationEventPublisher.publishEvent(
+          new PluginStateChangedMessage(integrationType.getName()));
       return new EntryCreatedRS(integrationType.getId());
     } catch (IOException e) {
       log.error("Error during file stream retrieving for plugin file '{}'", newPluginFileName, e);

--- a/src/main/java/com/epam/reportportal/base/core/integration/plugin/impl/DeletePluginHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/integration/plugin/impl/DeletePluginHandlerImpl.java
@@ -21,6 +21,7 @@ import static com.epam.reportportal.base.infrastructure.rules.commons.validation
 import com.epam.reportportal.base.core.events.domain.PluginDeletedEvent;
 import com.epam.reportportal.base.core.integration.plugin.DeletePluginHandler;
 import com.epam.reportportal.base.core.plugin.Pf4jPluginBox;
+import com.epam.reportportal.base.core.plugin.PluginStateChangedMessage;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.dao.IntegrationTypeRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.enums.ReservedIntegrationTypeEnum;
@@ -79,12 +80,23 @@ public class DeletePluginHandlerImpl implements DeletePluginHandler {
     applicationEventPublisher.publishEvent(
         new PluginDeletedEvent(pluginActivityResource, user.getUserId(), user.getUsername()));
 
+    /*
+     * Disable first and persist before touching the shared plugin file (plugins directory /
+     * data store): other instances discover enabled plugins by polling this row, so flipping
+     * it off closes the window where they'd try to (re)load a file this instance is about to
+     * delete from the shared data store.
+     */
+    integrationType.setEnabled(false);
+    integrationTypeRepository.save(integrationType);
+
     if (!pluginBox.deletePlugin(integrationType.getName())) {
       throw new ReportPortalException(
           ErrorType.PLUGIN_REMOVE_ERROR, "Unable to remove from plugin manager.");
     }
 
     integrationTypeRepository.deleteById(integrationType.getId());
+
+    applicationEventPublisher.publishEvent(new PluginStateChangedMessage(integrationType.getName()));
 
     return new OperationCompletionRS(
         Suppliers.formattedSupplier("Plugin = '{}' has been successfully removed",

--- a/src/main/java/com/epam/reportportal/base/core/integration/plugin/impl/UpdatePluginHandlerImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/integration/plugin/impl/UpdatePluginHandlerImpl.java
@@ -21,6 +21,7 @@ import static com.epam.reportportal.base.infrastructure.persistence.entity.enums
 import com.epam.reportportal.base.core.events.domain.PluginUpdatedEvent;
 import com.epam.reportportal.base.core.integration.plugin.UpdatePluginHandler;
 import com.epam.reportportal.base.core.plugin.Pf4jPluginBox;
+import com.epam.reportportal.base.core.plugin.PluginStateChangedMessage;
 import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.persistence.dao.IntegrationTypeRepository;
 import com.epam.reportportal.base.infrastructure.persistence.entity.integration.IntegrationType;
@@ -95,6 +96,8 @@ public class UpdatePluginHandlerImpl implements UpdatePluginHandler {
     }
 
     publishEvent(integrationType, user, isEnabled);
+
+    applicationEventPublisher.publishEvent(new PluginStateChangedMessage(integrationType.getName()));
 
     return new OperationCompletionRS(Suppliers.formattedSupplier(
         "Enabled state of the plugin with id = '{}' has been switched to - '{}'",

--- a/src/main/java/com/epam/reportportal/base/core/plugin/PluginStateChangedMessage.java
+++ b/src/main/java/com/epam/reportportal/base/core/plugin/PluginStateChangedMessage.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.core.plugin;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Broadcast on the {@code broadcast.events} fanout exchange whenever a plugin is installed,
+ * enabled, disabled, replaced or removed, so that every service-api instance - not just the one
+ * that handled the request - can reconcile its local plugin state immediately instead of waiting
+ * for its next {@link com.epam.reportportal.base.job.LoadPluginsJob} /
+ * {@link com.epam.reportportal.base.job.CleanOutdatedPluginsJob} poll.
+ *
+ * <p>Carries only the plugin id: the receiving instance re-reads the current state from the
+ * database rather than trusting a snapshot in the message, so delivery order and duplicate
+ * delivery don't matter.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PluginStateChangedMessage implements Serializable {
+
+  private String pluginId;
+
+}

--- a/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
+++ b/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
@@ -536,6 +536,7 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
     String newPluginId = newPluginInfo.getId();
     startUpPlugin(newPluginId);
     validateNewPluginExtensionClasses(newPluginId, uploadedPluginName);
+    destroyDependency(newPluginId);
     pluginManager.unloadPlugin(newPluginId);
 
     if (newPluginInfo.getDetails() != null) {
@@ -569,6 +570,7 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
                 .get()
         ));
     if (!pluginLoader.validatePluginExtensionClasses(newPlugin)) {
+      destroyDependency(newPluginId);
       pluginManager.unloadPlugin(newPluginId);
       deleteTempPlugin(newPluginFileName);
 

--- a/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
+++ b/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
@@ -536,8 +536,13 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
     String newPluginId = newPluginInfo.getId();
     startUpPlugin(newPluginId);
     validateNewPluginExtensionClasses(newPluginId, uploadedPluginName);
+    if (!pluginManager.unloadPlugin(newPluginId)) {
+      throw new ReportPortalException(ErrorType.PLUGIN_UPLOAD_ERROR,
+          Suppliers.formattedSupplier(
+              "Failed to unload plugin with id = '{}' before replacing it", newPluginId).get()
+      );
+    }
     destroyDependency(newPluginId);
-    pluginManager.unloadPlugin(newPluginId);
 
     if (newPluginInfo.getDetails() != null) {
       pluginDetails.setDetails(newPluginInfo.getDetails());
@@ -570,8 +575,13 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
                 .get()
         ));
     if (!pluginLoader.validatePluginExtensionClasses(newPlugin)) {
+      if (!pluginManager.unloadPlugin(newPluginId)) {
+        throw new ReportPortalException(ErrorType.PLUGIN_UPLOAD_ERROR,
+            Suppliers.formattedSupplier("Failed to unload the invalid plugin with id = '{}'",
+                newPluginId).get()
+        );
+      }
       destroyDependency(newPluginId);
-      pluginManager.unloadPlugin(newPluginId);
       deleteTempPlugin(newPluginFileName);
 
       throw new ReportPortalException(ErrorType.PLUGIN_UPLOAD_ERROR,

--- a/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
+++ b/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
@@ -52,7 +52,11 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -84,6 +88,14 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
   private final String resourcesDir;
 
   private final Cache<String, Path> uploadingPlugins;
+
+  /**
+   * Per-plugin-id locks serializing load/unload so the async startup loader
+   * ({@link com.epam.reportportal.base.plugin.PluginStartUpService}) and the scheduled
+   * {@link com.epam.reportportal.base.job.LoadPluginsJob} can't race to load/register the same
+   * plugin extension bean concurrently.
+   */
+  private final Map<String, Lock> pluginLocks = new ConcurrentHashMap<>();
 
   private final PluginLoader pluginLoader;
   private final IntegrationTypeRepository integrationTypeRepository;
@@ -187,6 +199,10 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
 
   @Override
   public boolean loadPlugin(String pluginId, IntegrationTypeDetails integrationTypeDetails) {
+    return withPluginLock(pluginId, () -> doLoadPlugin(pluginId, integrationTypeDetails));
+  }
+
+  private boolean doLoadPlugin(String pluginId, IntegrationTypeDetails integrationTypeDetails) {
     long loadBegin = System.currentTimeMillis();
     return ofNullable(integrationTypeDetails.getDetails()).map(details -> {
       String fileName = IntegrationTypeProperties.FILE_NAME.getValue(details)
@@ -273,11 +289,27 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
 
   @Override
   public boolean unloadPlugin(IntegrationType integrationType) {
-    applicationEventPublisher.publishEvent(
-        new PluginDeletedEvent(createPluginActivityResource(integrationType))
-    );
-    destroyDependency(integrationType.getName());
-    return pluginManager.unloadPlugin(integrationType.getName());
+    return withPluginLock(integrationType.getName(), () -> {
+      applicationEventPublisher.publishEvent(
+          new PluginDeletedEvent(createPluginActivityResource(integrationType))
+      );
+      destroyDependency(integrationType.getName());
+      return pluginManager.unloadPlugin(integrationType.getName());
+    });
+  }
+
+  /**
+   * Runs {@code action} while holding the lock for {@code pluginId}, serializing it against any
+   * other load/unload call for the same plugin id (see {@link #pluginLocks}).
+   */
+  private <T> T withPluginLock(String pluginId, Supplier<T> action) {
+    Lock lock = pluginLocks.computeIfAbsent(pluginId, _ -> new ReentrantLock());
+    lock.lock();
+    try {
+      return action.get();
+    } finally {
+      lock.unlock();
+    }
   }
 
   @Override

--- a/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
+++ b/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
@@ -293,8 +293,11 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
       applicationEventPublisher.publishEvent(
           new PluginDeletedEvent(createPluginActivityResource(integrationType))
       );
-      destroyDependency(integrationType.getName());
-      return pluginManager.unloadPlugin(integrationType.getName());
+      boolean unloaded = pluginManager.unloadPlugin(integrationType.getName());
+      if (unloaded) {
+        destroyDependency(integrationType.getName());
+      }
+      return unloaded;
     });
   }
 
@@ -401,6 +404,12 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
   public IntegrationType uploadPlugin(final String uploadedPluginName,
       final InputStream fileStream) {
     PluginInfo newPluginInfo = resolvePluginInfo(uploadedPluginName, fileStream);
+    return withPluginLock(newPluginInfo.getId(),
+        () -> doUploadPlugin(newPluginInfo, uploadedPluginName));
+  }
+
+  private IntegrationType doUploadPlugin(PluginInfo newPluginInfo,
+      final String uploadedPluginName) {
     IntegrationTypeDetails pluginDetails = pluginLoader.resolvePluginDetails(newPluginInfo);
 
     Optional<PluginWrapper> previousPlugin = getPluginById(newPluginInfo.getId());
@@ -538,13 +547,13 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
   }
 
   private void unloadPreviousPlugin(PluginWrapper pluginWrapper) {
-    destroyDependency(pluginWrapper.getPluginId());
     if (!pluginManager.unloadPlugin(pluginWrapper.getPluginId())) {
       throw new ReportPortalException(ErrorType.PLUGIN_REMOVE_ERROR,
           Suppliers.formattedSupplier("Failed to stop old plugin with id = '{}'",
               pluginWrapper.getPluginId()).get()
       );
     }
+    destroyDependency(pluginWrapper.getPluginId());
   }
 
   private void destroyDependency(String name) {

--- a/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
+++ b/src/main/java/com/epam/reportportal/base/plugin/Pf4jPluginManager.java
@@ -303,7 +303,7 @@ public class Pf4jPluginManager implements Pf4jPluginBox {
    * other load/unload call for the same plugin id (see {@link #pluginLocks}).
    */
   private <T> T withPluginLock(String pluginId, Supplier<T> action) {
-    Lock lock = pluginLocks.computeIfAbsent(pluginId, _ -> new ReentrantLock());
+    Lock lock = pluginLocks.computeIfAbsent(pluginId, id -> new ReentrantLock());
     lock.lock();
     try {
       return action.get();

--- a/src/main/java/com/epam/reportportal/base/ws/rabbit/PluginStateChangedConsumer.java
+++ b/src/main/java/com/epam/reportportal/base/ws/rabbit/PluginStateChangedConsumer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.base.ws.rabbit;
+
+import com.epam.reportportal.base.core.configs.Conditions;
+import com.epam.reportportal.base.core.plugin.PluginStateChangedMessage;
+import com.epam.reportportal.base.job.CleanOutdatedPluginsJob;
+import com.epam.reportportal.base.job.LoadPluginsJob;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * Reacts to {@link PluginStateChangedMessage} broadcasts (one per instance, via the {@code broadcast.events} fanout
+ * exchange / {@code eventsQueue}) by immediately re-running the same reconciliation the scheduled plugin jobs already
+ * perform, instead of waiting for their next poll. The message only carries a plugin id as a wake-up hint; the actual
+ * state is always re-read from the database by the jobs themselves, so this handler stays correct regardless of message
+ * ordering or duplicate delivery - including the publishing instance receiving its own broadcast back (a cheap no-op,
+ * since the change is already applied locally).
+ *
+ * <p>The scheduled jobs keep running independently as a safety net for missed broadcasts (e.g. a
+ * broker reconnect gap).
+ */
+@Slf4j
+@Component
+@Conditional(Conditions.NotTestCondition.class)
+@RequiredArgsConstructor
+public class PluginStateChangedConsumer {
+
+  private final LoadPluginsJob loadPluginsJob;
+  private final CleanOutdatedPluginsJob cleanOutdatedPluginsJob;
+
+  @RabbitListener(queues = "#{eventsQueue.name}", containerFactory = "rabbitListenerContainerFactory")
+  public void onPluginStateChanged(@Payload PluginStateChangedMessage message) {
+    log.debug("Received plugin state change broadcast for plugin id = '{}', reconciling now", message.getPluginId());
+    loadPluginsJob.execute();
+    cleanOutdatedPluginsJob.execute();
+  }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,8 +32,8 @@ management.endpoint.health.show-details=always
 management.server.base-path=/admin
 ## Supported period format details
 ## https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-
-com.ta.reportportal.job.load.plugins.cron=PT10S
-com.ta.reportportal.job.clean.outdated.plugins.cron=PT10S
+com.ta.reportportal.job.load.plugins.cron=PT30S
+com.ta.reportportal.job.clean.outdated.plugins.cron=PT30S
 com.ta.reportportal.job.interrupt.broken.launches.cron=PT1H
 com.ta.reportportal.job.clean.bids.cron=PT1H
 com.ta.reportportal.job.purge.revoked.tokens.cron=PT24H

--- a/src/test/java/com/epam/reportportal/base/plugin/Pf4jPluginManagerTest.java
+++ b/src/test/java/com/epam/reportportal/base/plugin/Pf4jPluginManagerTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.epam.reportportal.base.core.integration.impl.util.IntegrationTestUtil;
@@ -49,6 +51,7 @@ import org.pf4j.PluginRuntimeException;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory;
 import org.springframework.context.ApplicationEventPublisher;
 
 /**
@@ -67,7 +70,8 @@ class Pf4jPluginManagerTest {
   private final PluginLoader pluginLoader = mock(PluginLoader.class);
   private final IntegrationTypeRepository integrationTypeRepository = mock(
       IntegrationTypeRepository.class);
-  private final AutowireCapableBeanFactory beanFactory = mock(AutowireCapableBeanFactory.class);
+  private final AutowireCapableBeanFactory beanFactory = mock(
+      AbstractAutowireCapableBeanFactory.class);
   private final PluginManager pluginManager = mock(PluginManager.class);
   private final PluginWrapper previousPlugin = mock(PluginWrapper.class);
   private final PluginWrapper newPlugin = mock(PluginWrapper.class);
@@ -115,6 +119,7 @@ class Pf4jPluginManagerTest {
     when(pluginManager.getPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(newPlugin);
     when(pluginManager.getPluginsRoot()).thenReturn(FileSystems.getDefault().getPath(PLUGINS_PATH));
     when(pluginLoader.validatePluginExtensionClasses(newPlugin)).thenReturn(true);
+    when(pluginManager.unloadPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(true);
     doNothing().when(pluginLoader)
         .savePlugin(Paths.get(PLUGINS_PATH, NEW_PLUGIN_FILE_NAME), fileStream);
 
@@ -148,6 +153,7 @@ class Pf4jPluginManagerTest {
     when(pluginManager.getPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(newPlugin);
     when(pluginManager.getPluginsRoot()).thenReturn(FileSystems.getDefault().getPath(PLUGINS_PATH));
     when(pluginLoader.validatePluginExtensionClasses(newPlugin)).thenReturn(true);
+    when(pluginManager.unloadPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(true);
     String pluginFileName = NEW_JIRA_PLUGIN_ID + "-" + NEW_JIRA_PLUGIN_VERSION + ".jar";
     when(pluginManager.loadPlugin(Paths.get(PLUGINS_PATH, pluginFileName))).thenReturn(
         NEW_JIRA_PLUGIN_ID);
@@ -199,6 +205,7 @@ class Pf4jPluginManagerTest {
         NEW_JIRA_PLUGIN_ID);
     when(pluginManager.getPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(newPlugin);
     when(pluginManager.getPluginsRoot()).thenReturn(FileSystems.getDefault().getPath(PLUGINS_PATH));
+    when(pluginManager.unloadPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(true);
 
     final ReportPortalException exception = assertThrows(ReportPortalException.class,
         () -> pluginBox.uploadPlugin(NEW_PLUGIN_FILE_NAME, fileStream)
@@ -207,6 +214,72 @@ class Pf4jPluginManagerTest {
         "Error during plugin uploading: 'New plugin with id = 'new_jira' doesn't have mandatory extension classes.'",
         exception.getMessage()
     );
+  }
+
+  @Test
+  void uploadPluginWithFailedUnloadAfterValidation() throws PluginRuntimeException {
+
+    PluginInfo pluginInfo = getPluginInfo();
+    when(pluginLoader.extractPluginInfo(
+        Paths.get(PLUGINS_TEMP_PATH, NEW_PLUGIN_FILE_NAME))).thenReturn(pluginInfo);
+    IntegrationType jiraIntegrationType = IntegrationTestUtil.getJiraIntegrationType();
+    IntegrationTypeDetails jiraDetails = jiraIntegrationType.getDetails();
+    when(pluginLoader.resolvePluginDetails(pluginInfo)).thenReturn(jiraDetails);
+    when(pluginManager.getPlugin("old_jira")).then((i) -> {
+      pluginInfo.setId(NEW_JIRA_PLUGIN_ID);
+      return null;
+    });
+    when(pluginManager.loadPlugin(Paths.get(PLUGINS_TEMP_PATH, NEW_PLUGIN_FILE_NAME))).thenReturn(
+        NEW_JIRA_PLUGIN_ID);
+    when(pluginManager.getPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(newPlugin);
+    when(pluginManager.getPluginsRoot()).thenReturn(FileSystems.getDefault().getPath(PLUGINS_PATH));
+    when(pluginLoader.validatePluginExtensionClasses(newPlugin)).thenReturn(true);
+    // simulate PF4J refusing to unload the freshly-validated plugin
+    when(pluginManager.unloadPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(false);
+
+    final ReportPortalException exception = assertThrows(ReportPortalException.class,
+        () -> pluginBox.uploadPlugin(NEW_PLUGIN_FILE_NAME, fileStream)
+    );
+    assertEquals(
+        "Error during plugin uploading: 'Failed to unload plugin with id = 'new_jira' before replacing it'",
+        exception.getMessage()
+    );
+    // the operation must stop before touching plugin artifacts
+    verify(pluginLoader, never()).saveToDataStore(any(), any());
+    verify(integrationTypeRepository, never()).save(any(IntegrationType.class));
+  }
+
+  @Test
+  void uploadPluginWithFailedUnloadDuringValidation()
+      throws PluginRuntimeException, IOException {
+
+    PluginInfo pluginInfo = getPluginInfo();
+    when(pluginLoader.extractPluginInfo(
+        Paths.get(PLUGINS_TEMP_PATH, NEW_PLUGIN_FILE_NAME))).thenReturn(pluginInfo);
+    IntegrationType jiraIntegrationType = IntegrationTestUtil.getJiraIntegrationType();
+    IntegrationTypeDetails jiraDetails = jiraIntegrationType.getDetails();
+    when(pluginLoader.resolvePluginDetails(pluginInfo)).thenReturn(jiraDetails);
+    when(pluginManager.getPlugin("old_jira")).then((i) -> {
+      pluginInfo.setId(NEW_JIRA_PLUGIN_ID);
+      return null;
+    });
+    when(pluginManager.loadPlugin(Paths.get(PLUGINS_TEMP_PATH, NEW_PLUGIN_FILE_NAME))).thenReturn(
+        NEW_JIRA_PLUGIN_ID);
+    when(pluginManager.getPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(newPlugin);
+    when(pluginManager.getPluginsRoot()).thenReturn(FileSystems.getDefault().getPath(PLUGINS_PATH));
+    // extension classes invalid AND PF4J refuses to unload the rejected plugin
+    when(pluginLoader.validatePluginExtensionClasses(newPlugin)).thenReturn(false);
+    when(pluginManager.unloadPlugin(NEW_JIRA_PLUGIN_ID)).thenReturn(false);
+
+    final ReportPortalException exception = assertThrows(ReportPortalException.class,
+        () -> pluginBox.uploadPlugin(NEW_PLUGIN_FILE_NAME, fileStream)
+    );
+    assertEquals(
+        "Error during plugin uploading: 'Failed to unload the invalid plugin with id = 'new_jira''",
+        exception.getMessage()
+    );
+    // temp plugin artifact must be preserved since the unload never completed
+    verify(pluginLoader, never()).deleteTempPlugin(any(), any());
   }
 
   @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin changes are now synchronized across service instances shortly after installation, updates, enabling, disabling, or removal.
  * Plugin state changes are automatically reconciled without waiting for scheduled checks.

* **Bug Fixes**
  * Improved plugin operation reliability by detecting unload failures and preventing dependent cleanup from proceeding incorrectly.
  * Reduced the frequency of scheduled plugin loading and cleanup checks while retaining prompt event-driven synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->