### PR TITLE
EPMRPP-121359 || Prevent attacker-controlled TMS filenames from overwriting shared attachments

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -252,7 +252,7 @@
         value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
-      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$|^_$"/>
       <message key="name.invalidPattern"
         value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>

--- a/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsAttachmentController.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsAttachmentController.java
@@ -1,11 +1,14 @@
 package com.epam.reportportal.base.core.tms.controller;
 
-import com.epam.reportportal.base.infrastructure.persistence.binary.tms.TmsAttachmentDataStoreService;
 import com.epam.reportportal.base.core.tms.dto.UploadAttachmentRS;
 import com.epam.reportportal.base.core.tms.service.TmsAttachmentService;
+import com.epam.reportportal.base.infrastructure.persistence.binary.tms.TmsAttachmentDataStoreService;
+import com.epam.reportportal.base.infrastructure.persistence.commons.EntityUtils;
+import com.epam.reportportal.base.infrastructure.persistence.commons.ReportPortalUser;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
 import com.epam.reportportal.base.reporting.OperationCompletionRS;
+import com.epam.reportportal.base.util.ProjectExtractor;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,6 +19,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,9 +31,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 /**
  * REST Controller for TMS attachment operations.
- *
- * Provides endpoints for uploading, downloading, and deleting TMS attachments
- * that can be used in test case preconditions and manual scenario steps.
+ * <p>
+ * Provides endpoints for uploading, downloading, and deleting TMS attachments that can be used in test case
+ * preconditions and manual scenario steps.
  */
 @Slf4j
 @RestController
@@ -40,6 +44,7 @@ public class TmsAttachmentController {
 
   private final TmsAttachmentService tmsAttachmentService;
   private final TmsAttachmentDataStoreService tmsAttachmentDataStoreService;
+  private final ProjectExtractor projectExtractor;
 
   @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @Operation(summary = "Upload TMS attachment",
@@ -47,8 +52,12 @@ public class TmsAttachmentController {
   @PreAuthorize("hasPermission(#projectKey, 'allowedToEditProject')")
   public UploadAttachmentRS uploadAttachment(
       @Parameter(description = "Project key") @PathVariable String projectKey,
-      @Parameter(description = "Attachment file") @RequestParam("file") MultipartFile file) {
-    return tmsAttachmentService.uploadAttachment(file);
+      @Parameter(description = "Attachment file") @RequestParam("file") MultipartFile file,
+      @AuthenticationPrincipal ReportPortalUser user) {
+    var projectId = projectExtractor
+        .extractMembershipDetails(user, EntityUtils.normalizeId(projectKey))
+        .getProjectId();
+    return tmsAttachmentService.uploadAttachment(projectId, file);
   }
 
   @GetMapping("/{attachmentId}")
@@ -79,7 +88,7 @@ public class TmsAttachmentController {
         .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(attachment.getFileSize()))
         .body(resource);
   }
-  
+
   @GetMapping("/{attachmentId}/thumbnail")
   @Operation(summary = "Download TMS attachment thumbnail",
       description = "Downloads TMS attachment thumbnail file by ID")
@@ -95,7 +104,7 @@ public class TmsAttachmentController {
             "Attachment not found: " + attachmentId));
 
     if (attachment.getThumbnailPath() == null) {
-      throw new ReportPortalException(ErrorType.NOT_FOUND, 
+      throw new ReportPortalException(ErrorType.NOT_FOUND,
           "Thumbnail not found for attachment: " + attachmentId);
     }
 

--- a/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsAttachmentController.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/controller/TmsAttachmentController.java
@@ -31,8 +31,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 /**
  * REST Controller for TMS attachment operations.
- * <p>
- * Provides endpoints for uploading, downloading, and deleting TMS attachments that can be used in test case
+ *
+ * <p>Provides endpoints for uploading, downloading, and deleting TMS attachments that can be used in test case
  * preconditions and manual scenario steps.
  */
 @Slf4j

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentPersistenceService.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentPersistenceService.java
@@ -1,0 +1,26 @@
+package com.epam.reportportal.base.core.tms.service;
+
+import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsAttachmentRepository;
+import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsAttachment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Narrow DB-only persistence step for {@link TmsAttachment}, kept as a separate bean so its {@link Transactional}
+ * boundary never wraps blob storage IO (see {@link TmsAttachmentServiceImpl}).
+ */
+@Service
+@RequiredArgsConstructor
+public class TmsAttachmentPersistenceService {
+
+  private final TmsAttachmentRepository tmsAttachmentRepository;
+
+  /**
+   * Persists the attachment within its own short-lived transaction, forcing commit.
+   */
+  @Transactional
+  public TmsAttachment persist(TmsAttachment attachment) {
+    return tmsAttachmentRepository.save(attachment);
+  }
+}

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentService.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentService.java
@@ -15,10 +15,11 @@ public interface TmsAttachmentService {
   /**
    * Uploads an attachment file and creates a TmsAttachment entity with TTL.
    *
-   * @param file the multipart file to upload
+   * @param projectId the project ID to scope the attachment storage key
+   * @param file      the multipart file to upload
    * @return the created TmsAttachment with TTL set
    */
-  UploadAttachmentRS uploadAttachment(MultipartFile file);
+  UploadAttachmentRS uploadAttachment(Long projectId, MultipartFile file);
 
   /**
    * Downloads an attachment by ID.

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImpl.java
@@ -11,20 +11,22 @@ import com.epam.reportportal.base.infrastructure.persistence.dao.tms.TmsTextManu
 import com.epam.reportportal.base.infrastructure.persistence.entity.tms.TmsAttachment;
 import com.epam.reportportal.base.infrastructure.rules.exception.ErrorType;
 import com.epam.reportportal.base.infrastructure.rules.exception.ReportPortalException;
-import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,35 +50,59 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
 
   @Override
   @Transactional
-  public UploadAttachmentRS uploadAttachment(MultipartFile file) {
+  public UploadAttachmentRS uploadAttachment(Long projectId, MultipartFile file) {
     if (file.isEmpty()) {
       throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "File cannot be empty");
     }
 
+    var fileId = saveBinary(projectId, file);
+    var thumbnailId = saveThumbnailIfImage(projectId, file);
+
     try {
-      byte[] bytes = file.getBytes();
-      var fileId = tmsAttachmentDataStoreService.save(file.getOriginalFilename(),
-          new ByteArrayInputStream(bytes));
-
-      String thumbnailId = null;
-      if (isImage(file.getContentType())) {
-        try {
-          thumbnailId = tmsAttachmentDataStoreService.saveThumbnail(
-              "thumbnail_" + file.getOriginalFilename(),
-              new ByteArrayInputStream(bytes));
-        } catch (Exception e) {
-          log.warn("Failed to create thumbnail for file {}", file.getOriginalFilename(), e);
-        }
-      }
-
       var attachment = tmsAttachmentMapper.convertToAttachment(fileId, thumbnailId, file);
-
       return tmsAttachmentMapper.convertToUploadAttachmentRS(
           tmsAttachmentRepository.save(attachment));
-    } catch (Exception e) {
+    } catch (Exception _) {
+      // DB persistence failed after binaries were stored -> avoid orphaned blobs
+      deleteQuietly(fileId, thumbnailId);
       throw new ReportPortalException(ErrorType.BINARY_DATA_CANNOT_BE_SAVED,
-          "Failed to upload attachment: " + e.getMessage());
+          "Failed to persist attachment metadata for project " + projectId);
     }
+  }
+
+  private String saveBinary(Long projectId, MultipartFile file) {
+    try (var in = file.getInputStream()) {
+      var storageKey = buildStorageKey(projectId, file.getOriginalFilename());
+      return tmsAttachmentDataStoreService.save(storageKey, in);
+    } catch (IOException _) {
+      throw new ReportPortalException(ErrorType.BINARY_DATA_CANNOT_BE_SAVED,
+          "Failed to read/store attachment for project " + projectId);
+    }
+  }
+
+  private String saveThumbnailIfImage(Long projectId, MultipartFile file) {
+    if (!isImage(file.getContentType())) {
+      return null;
+    }
+    try (var in = file.getInputStream()) {
+      var thumbnailKey = buildThumbnailStorageKey(projectId, file.getOriginalFilename());
+      return tmsAttachmentDataStoreService.saveThumbnail(thumbnailKey, in);
+    } catch (Exception e) {
+      log.warn("Failed to create thumbnail for file {}", file.getOriginalFilename(), e);
+      return null;
+    }
+  }
+
+  private void deleteQuietly(String... storageKeys) {
+    Arrays.stream(storageKeys)
+        .filter(StringUtils::isNotBlank)
+        .forEach(key -> {
+          try {
+            tmsAttachmentDataStoreService.delete(key);
+          } catch (Exception e) {
+            log.error("Failed to clean up orphaned binary {}", key, e);
+          }
+        });
   }
 
   @Override
@@ -96,7 +122,7 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
     try {
       // Delete file from data store
       tmsAttachmentDataStoreService.delete(attachment.getPathToFile());
-      
+
       // Delete thumbnail if exists
       if (attachment.getThumbnailPath() != null) {
         try {
@@ -135,13 +161,13 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
       expiredAttachments.forEach(attachment -> {
         try {
           tmsAttachmentDataStoreService.delete(attachment.getPathToFile());
-          
+
           if (attachment.getThumbnailPath() != null) {
             tmsAttachmentDataStoreService.delete(attachment.getThumbnailPath());
           }
         } catch (Exception e) {
           log.warn("Failed to delete file/thumbnail for expired attachment {}: {}",
-               attachment.getId(), e.getMessage());
+              attachment.getId(), e.getMessage());
         }
       });
 
@@ -149,7 +175,7 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
       var expiredIds = expiredAttachments
           .stream()
           .map(TmsAttachment::getId)
-          .collect(Collectors.toList());
+          .toList();
       tmsAttachmentRepository.deleteByIds(expiredIds);
 
       log.debug("Cleaned up {} expired attachments", expiredIds.size());
@@ -182,14 +208,14 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
 
       // Step 3: Save file copy to data store
       var newFileId = tmsAttachmentDataStoreService.save(newFileName, originalFileStream);
-      
+
       // Step 3.1: Duplicate thumbnail if exists
       String newThumbnailId = null;
       if (originalAttachment.getThumbnailPath() != null) {
         try {
           var thumbnailStream = tmsAttachmentDataStoreService.load(originalAttachment.getThumbnailPath())
               .orElse(null);
-          
+
           if (thumbnailStream != null) {
             String newThumbnailName = "thumbnail_" + newFileName;
             newThumbnailId = tmsAttachmentDataStoreService.save(newThumbnailName, thumbnailStream);
@@ -248,7 +274,7 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
         .stream()
         .map(TmsAttachment::getId)
         .filter(id -> !usedAttachmentIds.contains(id))
-        .collect(Collectors.toList());
+        .toList();
 
     if (CollectionUtils.isEmpty(unusedAttachmentIds)) {
       log.debug("No unused TMS attachments found without TTL");
@@ -302,9 +328,9 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
   }
 
   /**
-   * Generates a unique filename for duplicated attachment. * Adds timestamp and UUID to avoid
-   * filename conflicts. * * @param originalFileName the original filename * @return new unique
-   * filename
+   * Generates a unique filename for duplicated attachment. * Adds timestamp and UUID to avoid filename conflicts. * *
+   *
+   * @param originalFileName the original filename * @return new unique filename
    */
   private String generateDuplicateFileName(String originalFileName) {
     if (originalFileName == null || originalFileName.trim().isEmpty()) {
@@ -326,5 +352,21 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
 
   private boolean isImage(String contentType) {
     return contentType != null && (contentType.equals("image/jpeg") || contentType.equals("image/png"));
+  }
+
+  private String buildStorageKey(Long projectId, String originalFilename) {
+    var safeName = sanitizeOriginalFilename(originalFilename);
+    return Paths.get(String.valueOf(projectId), UUID.randomUUID() + "_" + safeName).toString();
+  }
+
+  private String buildThumbnailStorageKey(Long projectId, String originalFilename) {
+    var safeName = sanitizeOriginalFilename(originalFilename);
+    return Paths.get(String.valueOf(projectId), "thumbnail_" + UUID.randomUUID() + "_" + safeName)
+        .toString();
+  }
+
+  private String sanitizeOriginalFilename(String originalFilename) {
+    var safeName = FilenameUtils.getName(StringUtils.defaultString(originalFilename));
+    return StringUtils.isBlank(safeName) ? "attachment" : safeName;
   }
 }

--- a/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImpl.java
+++ b/src/main/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImpl.java
@@ -40,6 +40,7 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
   private final TmsAttachmentRepository tmsAttachmentRepository;
   private final TmsAttachmentDataStoreService tmsAttachmentDataStoreService;
   private final TmsAttachmentMapper tmsAttachmentMapper;
+  private final TmsAttachmentPersistenceService tmsAttachmentPersistenceService;
   private final TmsStepAttachmentRepository tmsStepAttachmentRepository;
   private final TmsTextManualScenarioAttachmentRepository tmsTextManualScenarioAttachmentRepository;
   private final TmsManualScenarioPreconditionsAttachmentRepository tmsManualScenarioPreconditionsAttachmentRepository;
@@ -49,7 +50,6 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
   private Duration ttl;
 
   @Override
-  @Transactional
   public UploadAttachmentRS uploadAttachment(Long projectId, MultipartFile file) {
     if (file.isEmpty()) {
       throw new ReportPortalException(ErrorType.BAD_REQUEST_ERROR, "File cannot be empty");
@@ -60,10 +60,9 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
 
     try {
       var attachment = tmsAttachmentMapper.convertToAttachment(fileId, thumbnailId, file);
-      return tmsAttachmentMapper.convertToUploadAttachmentRS(
-          tmsAttachmentRepository.save(attachment));
+      var saved = tmsAttachmentPersistenceService.persist(attachment);
+      return tmsAttachmentMapper.convertToUploadAttachmentRS(saved);
     } catch (Exception _) {
-      // DB persistence failed after binaries were stored -> avoid orphaned blobs
       deleteQuietly(fileId, thumbnailId);
       throw new ReportPortalException(ErrorType.BINARY_DATA_CANNOT_BE_SAVED,
           "Failed to persist attachment metadata for project " + projectId);
@@ -74,7 +73,7 @@ public class TmsAttachmentServiceImpl implements TmsAttachmentService {
     try (var in = file.getInputStream()) {
       var storageKey = buildStorageKey(projectId, file.getOriginalFilename());
       return tmsAttachmentDataStoreService.save(storageKey, in);
-    } catch (IOException _) {
+    } catch (IOException | RuntimeException _) {
       throw new ReportPortalException(ErrorType.BINARY_DATA_CANNOT_BE_SAVED,
           "Failed to read/store attachment for project " + projectId);
     }

--- a/src/test/java/com/epam/reportportal/base/core/tms/controller/unit/TmsAttachmentControllerTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/controller/unit/TmsAttachmentControllerTest.java
@@ -123,7 +123,7 @@ public class TmsAttachmentControllerTest {
         .fileType("text/plain")
         .build();
 
-    given(tmsAttachmentService.uploadAttachment(any())).willReturn(uploadResponse);
+    given(tmsAttachmentService.uploadAttachment(eq(projectId), any())).willReturn(uploadResponse);
 
     // When/Then
     mockMvc.perform(
@@ -136,7 +136,8 @@ public class TmsAttachmentControllerTest {
         .andExpect(jsonPath("$.fileSize").value(22L))
         .andExpect(jsonPath("$.fileType").value("text/plain"));
 
-    verify(tmsAttachmentService).uploadAttachment(any());
+    verify(tmsAttachmentService).uploadAttachment(eq(projectId), any());
+    verify(projectExtractor).extractMembershipDetails(eq(testUser), eq(projectKey));
   }
 
   @Test
@@ -152,7 +153,7 @@ public class TmsAttachmentControllerTest {
         .fileType("image/png")
         .build();
 
-    given(tmsAttachmentService.uploadAttachment(any())).willReturn(uploadResponse);
+    given(tmsAttachmentService.uploadAttachment(eq(projectId), any())).willReturn(uploadResponse);
 
     // When/Then
     mockMvc.perform(
@@ -165,7 +166,7 @@ public class TmsAttachmentControllerTest {
         .andExpect(jsonPath("$.fileSize").value(5L))
         .andExpect(jsonPath("$.fileType").value("image/png"));
 
-    verify(tmsAttachmentService).uploadAttachment(any());
+    verify(tmsAttachmentService).uploadAttachment(eq(projectId), any());
   }
 
   @Test
@@ -181,7 +182,7 @@ public class TmsAttachmentControllerTest {
         .fileType("application/pdf")
         .build();
 
-    given(tmsAttachmentService.uploadAttachment(any())).willReturn(uploadResponse);
+    given(tmsAttachmentService.uploadAttachment(eq(projectId), any())).willReturn(uploadResponse);
 
     // When/Then
     mockMvc.perform(
@@ -194,7 +195,7 @@ public class TmsAttachmentControllerTest {
         .andExpect(jsonPath("$.fileSize").value(pdfContent.length))
         .andExpect(jsonPath("$.fileType").value("application/pdf"));
 
-    verify(tmsAttachmentService).uploadAttachment(any());
+    verify(tmsAttachmentService).uploadAttachment(eq(projectId), any());
   }
 
   @Test
@@ -364,7 +365,7 @@ public class TmsAttachmentControllerTest {
         .fileType("text/plain")
         .build();
 
-    given(tmsAttachmentService.uploadAttachment(any())).willReturn(uploadResponse);
+    given(tmsAttachmentService.uploadAttachment(eq(projectId), any())).willReturn(uploadResponse);
 
     // When/Then
     mockMvc.perform(
@@ -377,7 +378,7 @@ public class TmsAttachmentControllerTest {
         .andExpect(jsonPath("$.fileSize").value(0L))
         .andExpect(jsonPath("$.fileType").value("text/plain"));
 
-    verify(tmsAttachmentService).uploadAttachment(any());
+    verify(tmsAttachmentService).uploadAttachment(eq(projectId), any());
   }
 
   @Test
@@ -394,7 +395,7 @@ public class TmsAttachmentControllerTest {
         .fileType("text/plain")
         .build();
 
-    given(tmsAttachmentService.uploadAttachment(any())).willReturn(uploadResponse);
+    given(tmsAttachmentService.uploadAttachment(eq(projectId), any())).willReturn(uploadResponse);
 
     // When/Then
     mockMvc.perform(
@@ -407,7 +408,7 @@ public class TmsAttachmentControllerTest {
         .andExpect(jsonPath("$.fileSize").value(fileContent.length()))
         .andExpect(jsonPath("$.fileType").value("text/plain"));
 
-    verify(tmsAttachmentService).uploadAttachment(any());
+    verify(tmsAttachmentService).uploadAttachment(eq(projectId), any());
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImplTest.java
@@ -2,16 +2,19 @@ package com.epam.reportportal.base.core.tms.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -78,6 +81,8 @@ class TmsAttachmentServiceImplTest {
   private UploadAttachmentRS uploadAttachmentRS;
   private String fileId;
   private Long attachmentId;
+  private static final Long PROJECT_ID = 42L;
+  private static final Long OTHER_PROJECT_ID = 99L;
 
   @BeforeEach
   void setUp() {
@@ -118,14 +123,17 @@ class TmsAttachmentServiceImplTest {
         uploadAttachmentRS);
 
     // When uploading attachment
-    var result = sut.uploadAttachment(file);
+    var result = sut.uploadAttachment(PROJECT_ID, file);
 
     // Then attachment should be successfully uploaded
     assertNotNull(result);
     assertEquals(uploadAttachmentRS.getId(), result.getId());
     assertEquals(uploadAttachmentRS.getFileName(), result.getFileName());
 
-    verify(tmsAttachmentDataStoreService).save(eq("test.txt"), any(InputStream.class));
+    var storageKeyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(tmsAttachmentDataStoreService).save(storageKeyCaptor.capture(), any(InputStream.class));
+    assertTrue(storageKeyCaptor.getValue().startsWith(PROJECT_ID + "/"));
+    assertTrue(storageKeyCaptor.getValue().endsWith("_test.txt"));
     verify(tmsAttachmentMapper).convertToAttachment(eq(fileId), any(), eq(file));
     verify(tmsAttachmentRepository).save(attachment);
     verify(tmsAttachmentMapper).convertToUploadAttachmentRS(attachment);
@@ -138,7 +146,7 @@ class TmsAttachmentServiceImplTest {
 
     // When/Then exception should be thrown for empty file
     var exception = assertThrows(ReportPortalException.class,
-        () -> sut.uploadAttachment(emptyFile));
+        () -> sut.uploadAttachment(PROJECT_ID, emptyFile));
 
     assertEquals(ErrorType.BAD_REQUEST_ERROR, exception.getErrorType());
     assertEquals(
@@ -157,13 +165,42 @@ class TmsAttachmentServiceImplTest {
 
     // When/Then exception should be thrown when storage fails
     var exception = assertThrows(ReportPortalException.class,
-        () -> sut.uploadAttachment(file));
+        () -> sut.uploadAttachment(PROJECT_ID, file));
 
     assertEquals(ErrorType.BINARY_DATA_CANNOT_BE_SAVED, exception.getErrorType());
     assertTrue(exception.getMessage().contains("Failed to upload attachment"));
 
-    verify(tmsAttachmentDataStoreService).save(eq("test.txt"), any(InputStream.class));
+    var storageKeyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(tmsAttachmentDataStoreService).save(storageKeyCaptor.capture(), any(InputStream.class));
+    assertTrue(storageKeyCaptor.getValue().startsWith(PROJECT_ID + "/"));
+    assertTrue(storageKeyCaptor.getValue().endsWith("_test.txt"));
     verifyNoInteractions(tmsAttachmentRepository);
+  }
+
+  @Test
+  void uploadAttachment_ShouldUseDistinctProjectScopedStorageKeys_WhenSameOriginalFilename() {
+    when(tmsAttachmentDataStoreService.save(anyString(), any(InputStream.class)))
+        .thenReturn("file-id-1", "file-id-2");
+    when(tmsAttachmentMapper.convertToAttachment(anyString(), any(), eq(file))).thenReturn(
+        attachment);
+    when(tmsAttachmentRepository.save(attachment)).thenReturn(attachment);
+    when(tmsAttachmentMapper.convertToUploadAttachmentRS(attachment)).thenReturn(
+        uploadAttachmentRS);
+
+    sut.uploadAttachment(PROJECT_ID, file);
+    sut.uploadAttachment(OTHER_PROJECT_ID, file);
+
+    var storageKeyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(tmsAttachmentDataStoreService, times(2))
+        .save(storageKeyCaptor.capture(), any(InputStream.class));
+
+    var storageKeys = storageKeyCaptor.getAllValues();
+    assertEquals(2, storageKeys.size());
+    assertNotEquals(storageKeys.get(0), storageKeys.get(1));
+    assertTrue(storageKeys.get(0).startsWith(PROJECT_ID + "/"));
+    assertTrue(storageKeys.get(1).startsWith(OTHER_PROJECT_ID + "/"));
+    assertTrue(storageKeys.get(0).endsWith("_test.txt"));
+    assertTrue(storageKeys.get(1).endsWith("_test.txt"));
   }
 
   @Test

--- a/src/test/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImplTest.java
+++ b/src/test/java/com/epam/reportportal/base/core/tms/service/TmsAttachmentServiceImplTest.java
@@ -62,6 +62,9 @@ class TmsAttachmentServiceImplTest {
   private TmsAttachmentMapper tmsAttachmentMapper;
 
   @Mock
+  private TmsAttachmentPersistenceService tmsAttachmentPersistenceService;
+
+  @Mock
   private TmsStepAttachmentRepository tmsStepAttachmentRepository;
 
   @Mock
@@ -118,7 +121,7 @@ class TmsAttachmentServiceImplTest {
         fileId);
     when(tmsAttachmentMapper.convertToAttachment(eq(fileId), any(), eq(file))).thenReturn(
         attachment);
-    when(tmsAttachmentRepository.save(attachment)).thenReturn(attachment);
+    when(tmsAttachmentPersistenceService.persist(attachment)).thenReturn(attachment);
     when(tmsAttachmentMapper.convertToUploadAttachmentRS(attachment)).thenReturn(
         uploadAttachmentRS);
 
@@ -135,7 +138,7 @@ class TmsAttachmentServiceImplTest {
     assertTrue(storageKeyCaptor.getValue().startsWith(PROJECT_ID + "/"));
     assertTrue(storageKeyCaptor.getValue().endsWith("_test.txt"));
     verify(tmsAttachmentMapper).convertToAttachment(eq(fileId), any(), eq(file));
-    verify(tmsAttachmentRepository).save(attachment);
+    verify(tmsAttachmentPersistenceService).persist(attachment);
     verify(tmsAttachmentMapper).convertToUploadAttachmentRS(attachment);
   }
 
@@ -154,12 +157,12 @@ class TmsAttachmentServiceImplTest {
         exception.getMessage());
 
     verifyNoInteractions(tmsAttachmentDataStoreService, tmsAttachmentMapper,
-        tmsAttachmentRepository);
+        tmsAttachmentPersistenceService);
   }
 
   @Test
   void uploadAttachment_ShouldThrowException_WhenDataStoreServiceFails() throws Exception {
-    // Given data store service throws IOException
+    // Given data store service throws an unchecked exception
     when(tmsAttachmentDataStoreService.save(anyString(), any(InputStream.class)))
         .thenThrow(new RuntimeException("Storage error"));
 
@@ -168,13 +171,32 @@ class TmsAttachmentServiceImplTest {
         () -> sut.uploadAttachment(PROJECT_ID, file));
 
     assertEquals(ErrorType.BINARY_DATA_CANNOT_BE_SAVED, exception.getErrorType());
-    assertTrue(exception.getMessage().contains("Failed to upload attachment"));
+    assertTrue(exception.getMessage().contains("Failed to read/store attachment"));
 
     var storageKeyCaptor = ArgumentCaptor.forClass(String.class);
     verify(tmsAttachmentDataStoreService).save(storageKeyCaptor.capture(), any(InputStream.class));
     assertTrue(storageKeyCaptor.getValue().startsWith(PROJECT_ID + "/"));
     assertTrue(storageKeyCaptor.getValue().endsWith("_test.txt"));
-    verifyNoInteractions(tmsAttachmentRepository);
+    verifyNoInteractions(tmsAttachmentPersistenceService);
+  }
+
+  @Test
+  void uploadAttachment_ShouldDeleteOrphanedBlob_WhenPersistenceServiceFails() {
+    // Given the blob is stored successfully but the DB write fails
+    when(tmsAttachmentDataStoreService.save(anyString(), any(InputStream.class))).thenReturn(
+        fileId);
+    when(tmsAttachmentMapper.convertToAttachment(eq(fileId), any(), eq(file))).thenReturn(
+        attachment);
+    when(tmsAttachmentPersistenceService.persist(attachment))
+        .thenThrow(new RuntimeException("DB error"));
+
+    // When/Then exception should be thrown and the orphaned blob cleaned up
+    var exception = assertThrows(ReportPortalException.class,
+        () -> sut.uploadAttachment(PROJECT_ID, file));
+
+    assertEquals(ErrorType.BINARY_DATA_CANNOT_BE_SAVED, exception.getErrorType());
+    assertTrue(exception.getMessage().contains("Failed to persist attachment metadata"));
+    verify(tmsAttachmentDataStoreService).delete(fileId);
   }
 
   @Test
@@ -183,7 +205,7 @@ class TmsAttachmentServiceImplTest {
         .thenReturn("file-id-1", "file-id-2");
     when(tmsAttachmentMapper.convertToAttachment(anyString(), any(), eq(file))).thenReturn(
         attachment);
-    when(tmsAttachmentRepository.save(attachment)).thenReturn(attachment);
+    when(tmsAttachmentPersistenceService.persist(attachment)).thenReturn(attachment);
     when(tmsAttachmentMapper.convertToUploadAttachmentRS(attachment)).thenReturn(
         uploadAttachmentRS);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Attachment uploads are now correctly associated with the selected project.
  - Files with identical names uploaded to different projects no longer overwrite or conflict with one another.
  - Attachment storage now handles special characters in filenames more reliably.
  - Failed uploads clean up partially stored data to prevent orphaned files.
  - Attachment metadata is saved more reliably when storing uploaded files.

- **Tests**
  - Expanded coverage for project-scoped uploads, filename handling, and cleanup after storage failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->